### PR TITLE
EL-2283: Add github action to delete UAT releases after merge

### DIFF
--- a/.github/actions/delete-uat-release/action.yml
+++ b/.github/actions/delete-uat-release/action.yml
@@ -1,0 +1,86 @@
+name: "Delete UAT deployment"
+description: 'Deletes a UAT deployment with a name that matches the merged or closed branch'
+inputs:
+  k8s_cluster:
+    description: "Kubernetes cluster name"
+    required: true
+  k8s_cluster_cert:
+    description: "Kubernetes cluster certificate"
+    required: true
+  k8s_namespace:
+    description: "Kubernetes cluster namespace"
+    required: true
+  k8s_token:
+    description: "Kubernetes authentication token"
+    required: true
+  branch_name:
+    description: "Optional branch name - inferred if not given"
+    required: false
+outputs:
+  branch-name:
+    description: "Extracted branch name"
+    value: ${{ steps.extract_branch.outputs.branch }}
+  release-name:
+    description: "Extracted release name"
+    value: ${{ steps.extract_release.outputs.release }}
+  delete-message:
+    description: "Extracted delete message"
+    value: ${{ steps.delete_release.outputs.message }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extract branch name
+      id: extract_branch
+      shell: bash
+      env:
+        BRANCH_NAME: ${{ inputs.branch_name || 'not_given' }}
+      run: |
+        if [ $BRANCH_NAME == "not_given" ]
+        then
+          branch=$GITHUB_HEAD_REF
+        else
+          branch=$BRANCH_NAME
+        fi
+
+        echo "branch=$branch" >> $GITHUB_OUTPUT
+
+    - name: Extract release name
+      id: extract_release
+      shell: bash
+      run: |
+        branch=${{ steps.extract_branch.outputs.branch }}
+        truncated_branch=$(echo $branch | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-18 | sed 's/-$//')
+        echo "release=$truncated_branch" >> $GITHUB_OUTPUT
+
+    - name: Authenticate to the cluster
+      id: authenticate_to_cluster
+      shell: bash
+      env:
+        K8S_CLUSTER: ${{ inputs.k8s_cluster }}
+        K8S_CLUSTER_CERT: ${{ inputs.k8s_cluster_cert }}
+        K8S_NAMESPACE: ${{ inputs.k8s_namespace }}
+        K8S_TOKEN: ${{ inputs.k8s_token }}
+      run: |
+        echo "${K8S_CLUSTER_CERT}" > ./ca.crt
+        kubectl config set-cluster ${K8S_CLUSTER} --certificate-authority=./ca.crt --server=https://${K8S_CLUSTER}
+        kubectl config set-credentials circleci --token=${K8S_TOKEN}
+        kubectl config set-context ${K8S_CLUSTER} --cluster=${K8S_CLUSTER} --user=circleci --namespace=${K8S_NAMESPACE}
+        kubectl config use-context ${K8S_CLUSTER}
+
+    - name: Delete UAT release
+      id: delete_release
+      shell: bash
+      run: |
+        release_name=${{ steps.extract_release.outputs.release }}
+        found=$(helm list --all | grep $release_name || [[ $? == 1 ]])
+
+        if [[ ! -z "$found" ]]
+        then
+          helm delete $release_name
+          echo "message=\"Deleted UAT release ${release_name}\"" >> $GITHUB_OUTPUT
+          kubectl delete pvc data-$release_name-postgresql-0
+          echo "message=\"Deleted PVC for release ${release_name}\"" >> $GITHUB_OUTPUT
+        else
+          echo "message=\"UAT release, ${release_name}, not found\"" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/delete_uat_release.yml
+++ b/.github/workflows/delete_uat_release.yml
@@ -1,0 +1,23 @@
+name: Delete UAT release
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  delete_uat_job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Delete from UAT namespace
+        id: delete_uat
+        uses: ./.github/actions/delete-uat-release
+        with:
+          k8s_cluster: ${{ secrets.KUBE_CLUSTER }}
+          k8s_cluster_cert: ${{ secrets.KUBE_CERT }}
+          k8s_namespace: ${{ secrets.KUBE_NAMESPACE }}
+          k8s_token: ${{ secrets.KUBE_TOKEN }}
+      - name: Result
+        shell: bash
+        run: echo ${{ steps.delete_uat.outputs.delete-message }}\


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-2283)

## What changed and Why?

- If applied, this creates  a workflow to delete a UAT release and the associated action.

## Guidance to review (optional)

- This is an exact copy of the CCQ approach (with updates only to the secrets used).
  - https://github.com/ministryofjustice/laa-check-client-qualifies/blob/main/.github/actions/delete-uat-release/action.yml
  - https://github.com/ministryofjustice/laa-check-client-qualifies/blob/main/.github/workflows/delete_uat_release.yml

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.