### PR TITLE
EL-2572 - Type-Safe Validation Error Handling

### DIFF
--- a/src/middlewares/phoneNumberSchema.ts
+++ b/src/middlewares/phoneNumberSchema.ts
@@ -1,6 +1,7 @@
 import { hasProperty, isRecord } from '#src/scripts/helpers/dataTransformers.js';
 import { checkSchema, type Meta } from 'express-validator';
 import { isValidPhoneNumber } from 'libphonenumber-js';
+import { TypedValidationError } from '#src/scripts/helpers/ValidationErrorHelpers.js';
 
 interface ClientPhoneNumberBody {
   phoneNumber: string;
@@ -41,20 +42,18 @@ export const validateEditClientPhoneNumber = (): ReturnType<typeof checkSchema> 
          */
         options: (numberInputted: string): true => {
           if (numberInputted.trim() === '') {
-            const errorData = {
+            throw new TypedValidationError({
               summaryMessage: 'Enter the client phone number',
               inlineMessage: 'Enter the phone number'
-            };
-            throw new Error(JSON.stringify(errorData));
+            });
           }
 
           const valid = isValidPhoneNumber(numberInputted, 'GB') || isValidPhoneNumber(numberInputted, 'IN');
           if (!valid) {
-            const errorData = {
+            throw new TypedValidationError({
               summaryMessage: 'Enter the phone number in the correct format',
               inlineMessage: 'Enter the phone number in the correct format'
-            };
-            throw new Error(JSON.stringify(errorData));
+            });
           }
 
           return true;
@@ -78,11 +77,10 @@ export const validateEditClientPhoneNumber = (): ReturnType<typeof checkSchema> 
           const phoneChanged = req.body.phoneNumber !== req.body.existingPhoneNumber;
           const safeToCallChanged = req.body.safeToCall !== req.body.existingSafeToCall;
           if (!phoneChanged && !safeToCallChanged) {
-            const errorData = {
-              summaryMessage: 'Update if the client is safe to call, update the client phone number, or select ‘Cancel’',
-              inlineMessage: '',
-            };
-            throw new Error(JSON.stringify(errorData));
+            throw new TypedValidationError({
+              summaryMessage: 'Update if the client is safe to call, update the client phone number, or select \'Cancel\'',
+              inlineMessage: 'You must make a change before saving',
+            });
           }
           return true;
         },

--- a/src/middlewares/phoneNumberSchema.ts
+++ b/src/middlewares/phoneNumberSchema.ts
@@ -35,29 +35,36 @@ export const validateEditClientPhoneNumber = (): ReturnType<typeof checkSchema> 
       trim: true,
       custom: {
         /**
-         * Schema to check if the number inputted is empty and/or valid UK or International phone number.
+         * Schema to check if the number inputted is valid UK or International phone number.
          * @param {string} numberInputted - The number user has inputted
-         * @returns {true} Returns true if the phone number is valid
-         * @throws {Error} Throws error with a user-friendly message if invalid
+         * @returns {boolean} Returns true if the phone number is valid, false otherwise
          */
-        options: (numberInputted: string): true => {
+        options: (numberInputted: string): boolean => {
           if (numberInputted.trim() === '') {
-            throw new TypedValidationError({
-              summaryMessage: 'Enter the client phone number',
-              inlineMessage: 'Enter the phone number'
-            });
+            return true; // Let the notEmpty validator handle empty values
           }
 
           const valid = isValidPhoneNumber(numberInputted, 'GB') || isValidPhoneNumber(numberInputted, 'IN');
-          if (!valid) {
-            throw new TypedValidationError({
-              summaryMessage: 'Enter the phone number in the correct format',
-              inlineMessage: 'Enter the phone number in the correct format'
-            });
-          }
-
-          return true;
+          return valid;
         },
+        /**
+         * Custom error message for invalid phone number format
+         * @returns {TypedValidationError} Returns TypedValidationError with structured error data
+         */
+        errorMessage: () => new TypedValidationError({
+          summaryMessage: 'Enter the phone number in the correct format',
+          inlineMessage: 'Enter the phone number in the correct format'
+        })
+      },
+      notEmpty: {
+        /**
+         * Custom error message for empty phone number
+         * @returns {TypedValidationError} Returns TypedValidationError with structured error data
+         */
+        errorMessage: () => new TypedValidationError({
+          summaryMessage: 'Enter the client phone number',
+          inlineMessage: 'Enter the phone number'
+        })
       },
     },
     notChanged: {
@@ -76,14 +83,16 @@ export const validateEditClientPhoneNumber = (): ReturnType<typeof checkSchema> 
           }
           const phoneChanged = req.body.phoneNumber !== req.body.existingPhoneNumber;
           const safeToCallChanged = req.body.safeToCall !== req.body.existingSafeToCall;
-          if (!phoneChanged && !safeToCallChanged) {
-            throw new TypedValidationError({
-              summaryMessage: 'Update if the client is safe to call, update the client phone number, or select \'Cancel\'',
-              inlineMessage: 'You must make a change before saving',
-            });
-          }
-          return true;
+          return phoneChanged || safeToCallChanged;
         },
+        /**
+         * Custom error message for when no changes are made
+         * @returns {TypedValidationError} Returns TypedValidationError with structured error data
+         */
+        errorMessage: () => new TypedValidationError({
+          summaryMessage: 'Update if the client is safe to call, update the client phone number, or select \'Cancel\'',
+          inlineMessage: '',
+        })
       },
     },
   });

--- a/src/scripts/controllers/editClientDetailsController.ts
+++ b/src/scripts/controllers/editClientDetailsController.ts
@@ -181,19 +181,17 @@ export async function postEditClientPhoneNumber(req: Request, res: Response, nex
   const validationErrors: Result<ValidationErrorData> = validationResult(req).formatWith(formatValidationError);
 
   if (!validationErrors.isEmpty()) {
-    const resultingErrors = validationErrors.array().map((errorData: ValidationErrorData) => {
-      // Use inlineMessage if it's not empty, otherwise fallback to summaryMessage
-      const inlineMessage = errorData.inlineMessage !== '' ? errorData.inlineMessage : errorData.summaryMessage;
+    const resultingErrors = validationErrors.array().map((errorData: ValidationErrorData) => ({
+      fieldName: 'phoneNumber',
+      inlineMessage: errorData.inlineMessage,
+      summaryMessage: errorData.summaryMessage,
+    }));
 
-      return {
-        fieldName: 'phoneNumber',
-        inlineMessage,
-        summaryMessage: errorData.summaryMessage,
-      };
-    });
-
+    // Only use inline messages that are not empty
     const inputErrors = resultingErrors.reduce<Record<string, string>>((acc, { fieldName, inlineMessage }) => {
-      acc[fieldName] = inlineMessage;
+      if (inlineMessage.trim() !== '') {
+        acc[fieldName] = inlineMessage;
+      }
       return acc;
     }, {});
 

--- a/src/scripts/helpers/ValidationErrorHelpers.ts
+++ b/src/scripts/helpers/ValidationErrorHelpers.ts
@@ -1,0 +1,59 @@
+import type { ValidationError } from 'express-validator';
+import { isRecord, hasProperty, safeString } from './dataTransformers.js';
+
+/**
+ * Interface for validation error data structure
+ */
+export interface ValidationErrorData {
+  summaryMessage: string;
+  inlineMessage: string;
+}
+
+/**
+ * Custom error class that extends Error and carries ValidationErrorData
+ * This satisfies linting rules while providing type safety
+ */
+export class TypedValidationError extends Error {
+  public readonly errorData: ValidationErrorData;
+
+  /**
+   * Creates a new TypedValidationError with structured error data
+   * @param {ValidationErrorData} errorData - The validation error data containing summary and inline messages
+   */
+  constructor(errorData: ValidationErrorData) {
+    super(errorData.summaryMessage);
+    this.name = 'TypedValidationError';
+    this.errorData = errorData;
+  }
+}
+
+/**
+ * Custom error formatter for express-validator that preserves type safety
+ * This is the express-validator recommended approach using formatWith()
+ * @param {ValidationError} error - The express-validator error object
+ * @returns {ValidationErrorData} Typed error data object
+ */
+export function formatValidationError(error: ValidationError): ValidationErrorData {
+  // Handle TypedValidationError instances
+  if (error.msg instanceof TypedValidationError) {
+    return error.msg.errorData;
+  }
+
+  // Handle the case where the error message is already our ValidationErrorData using existing helpers
+  if (isRecord(error.msg) &&
+    hasProperty(error.msg, 'summaryMessage') &&
+    hasProperty(error.msg, 'inlineMessage')) {
+    return {
+      summaryMessage: safeString(error.msg.summaryMessage),
+      inlineMessage: safeString(error.msg.inlineMessage)
+    };
+  }
+
+  // Fallback: treat the message as both summary and inline
+  const safeMessage = safeString(error.msg);
+  const message = safeMessage !== '' ? safeMessage : 'Invalid value';
+  return {
+    summaryMessage: message,
+    inlineMessage: message
+  };
+}


### PR DESCRIPTION
[Jira ticket: EL-2572](https://dsdmoj.atlassian.net/browse/EL-2572)

## Type-Safe Validation Error Handling

This implementation addresses **express-validator**'s limitation of converting all error messages to strings internally.  
To preserve type safety while working within these constraints:

1. Custom validators throw `TypedValidationError` instances containing structured data.
2. `formatValidationError()` extracts the typed error data using existing `dataTransformers` helpers.
3. The result is properly typed `ValidationErrorData` objects instead of raw strings.

### Benefits
- Full TypeScript type safety for error messages.
- Separation of summary (for error lists) vs inline (for field highlights) messages.
- Consistent error handling using existing codebase utilities.

### Express-validator Limitation
- The library internally converts all custom validator errors to the `msg` property.
- `formatWith()` is the recommended workaround to restore type information.