### PR TITLE
EL-2458: change client contact address

### DIFF
--- a/routes/editClientDetails.ts
+++ b/routes/editClientDetails.ts
@@ -22,7 +22,7 @@ router.post('/:caseReference/client-details/edit/email-address', postEditClientE
 router.get('/:caseReference/client-details/edit/phone-number', getEditClientPhoneNumber);
 router.post('/:caseReference/client-details/edit/phone-number', validateEditClientPhoneNumber(), postEditClientPhoneNumber);
 
-router.get('/:caseReference/client-details/edit/address', getEditClientAddress);
-router.post('/:caseReference/client-details/edit/address', validateEditClientAddress(), postEditClientAddress);
+router.get('/:caseReference/client-details/change/address', getEditClientAddress);
+router.post('/:caseReference/client-details/change/address', validateEditClientAddress(), postEditClientAddress);
 
 export default router;

--- a/routes/editClientDetails.ts
+++ b/routes/editClientDetails.ts
@@ -7,7 +7,9 @@ import {
   getEditClientPhoneNumber,
   postEditClientPhoneNumber
 } from '#src/scripts/controllers/editClientDetailsController.js';
+import { getEditClientAddress, postEditClientAddress } from '#src/scripts/controllers/editClientAddressController.js';
 import { validateEditClientPhoneNumber } from '#src/middlewares/phoneNumberSchema.js';
+import { validateEditClientAddress } from '#src/middlewares/clientAddressSchema.js';
 
 const router = express.Router();
 
@@ -19,5 +21,8 @@ router.post('/:caseReference/client-details/edit/email-address', postEditClientE
 
 router.get('/:caseReference/client-details/edit/phone-number', getEditClientPhoneNumber);
 router.post('/:caseReference/client-details/edit/phone-number', validateEditClientPhoneNumber(), postEditClientPhoneNumber);
+
+router.get('/:caseReference/client-details/edit/address', getEditClientAddress);
+router.post('/:caseReference/client-details/edit/address', validateEditClientAddress(), postEditClientAddress);
 
 export default router;

--- a/src/middlewares/clientAddressSchema.ts
+++ b/src/middlewares/clientAddressSchema.ts
@@ -36,17 +36,6 @@ export const validateEditClientAddress = (): ReturnType<typeof checkSchema> =>
     postcode: {
       in: ['body'],
       trim: true,
-      customSanitizer: {
-        /**
-         * Converts postcode to uppercase for consistent formatting
-         * @param {string} value - The postcode value to convert
-         * @returns {string} The postcode in uppercase
-         */
-        options: (value: string) => 
-          // Convert postcode to uppercase if provided
-           typeof value === 'string' ? value.toUpperCase() : value
-        
-      },
     },
     notChanged: {
       in: ['body'],

--- a/src/middlewares/clientAddressSchema.ts
+++ b/src/middlewares/clientAddressSchema.ts
@@ -15,6 +15,9 @@ export const validateEditClientAddress = (): ReturnType<typeof checkSchema> =>
     postcode: {
       in: ['body'],
       trim: true,
+      customSanitizer: {
+        options: (value: string) => typeof value === 'string' ? value.toUpperCase() : value
+      },
     },
     notChanged: createChangeDetectionValidator(
       [

--- a/src/middlewares/clientAddressSchema.ts
+++ b/src/middlewares/clientAddressSchema.ts
@@ -12,10 +12,21 @@ export const validateEditClientAddress = (): ReturnType<typeof checkSchema> =>
       in: ['body'],
       trim: true,
     },
+    /**
+     * Postcode field validation and sanitisation.
+     * Converts postcode to uppercase for consistency.
+     * @param {string} value - The postcode value to sanitise.
+     * @returns {string} The sanitised postcode in uppercase, or the original value if not a string.
+     */
     postcode: {
       in: ['body'],
       trim: true,
       customSanitizer: {
+        /**
+         * Sanitises the postcode value to uppercase.
+         * @param {string} value - The postcode value to sanitise.
+         * @returns {string} The sanitised postcode in uppercase, or the original value if not a string.
+         */
         options: (value: string) => typeof value === 'string' ? value.toUpperCase() : value
       },
     },

--- a/src/middlewares/clientAddressSchema.ts
+++ b/src/middlewares/clientAddressSchema.ts
@@ -1,0 +1,81 @@
+import { hasProperty, isRecord } from '#src/scripts/helpers/dataTransformers.js';
+import { checkSchema, type Meta } from 'express-validator';
+import { TypedValidationError } from '#src/scripts/helpers/ValidationErrorHelpers.js';
+
+interface ClientAddressBody {
+  address: string;
+  postcode: string;
+  existingAddress: string;
+  existingPostcode: string;
+}
+
+/**
+ * Checks whether the given body object has the expected structure of ClientAddressBody.
+ * @param {unknown} body - The body object to check
+ * @returns {body is ClientAddressBody} True if the body matches ClientAddressBody shape
+ */
+function isClientAddressBody(body: unknown): body is ClientAddressBody {
+  return isRecord(body) &&
+    hasProperty(body, 'address') &&
+    hasProperty(body, 'postcode') &&
+    hasProperty(body, 'existingAddress') &&
+    hasProperty(body, 'existingPostcode');
+}
+
+/**
+ * Validation middleware when user edits client's contact address.
+ * Validates address and postcode fields with postcode uppercase conversion and change detection.
+ * @returns {Error} Validation schema for express-validator
+ */
+export const validateEditClientAddress = (): ReturnType<typeof checkSchema> =>
+  checkSchema({
+    address: {
+      in: ['body'],
+      trim: true,
+    },
+    postcode: {
+      in: ['body'],
+      trim: true,
+      customSanitizer: {
+        /**
+         * Converts postcode to uppercase for consistent formatting
+         * @param {string} value - The postcode value to convert
+         * @returns {string} The postcode in uppercase
+         */
+        options: (value: string) => 
+          // Convert postcode to uppercase if provided
+           typeof value === 'string' ? value.toUpperCase() : value
+        
+      },
+    },
+    notChanged: {
+      in: ['body'],
+      custom: {
+        /**
+         * Schema to check if the address or postcode values have been unchanged (AC5).
+         * @param {string} _value - Placeholder value (unused)
+         * @param {Meta} meta - `express-validator` context containing request object
+         * @returns {boolean} True if address or postcode has changed
+         */
+        options: (_value: string, meta: Meta): boolean => {
+          const { req } = meta;
+          if (!isClientAddressBody(req.body)) {
+            return true;
+          }
+          
+          const addressChanged = req.body.address.trim() !== req.body.existingAddress.trim();
+          const postcodeChanged = req.body.postcode.trim() !== req.body.existingPostcode.trim();
+          
+          return addressChanged || postcodeChanged;
+        },
+        /**
+         * Custom error message for when no changes are made (AC5)
+         * @returns {TypedValidationError} Returns TypedValidationError with structured error data
+         */
+        errorMessage: () => new TypedValidationError({
+          summaryMessage: 'Update the client address, update the postcode, or select \'Cancel\'',
+          inlineMessage: '',
+        })
+      },
+    },
+  });

--- a/src/middlewares/clientAddressSchema.ts
+++ b/src/middlewares/clientAddressSchema.ts
@@ -22,7 +22,7 @@ export const validateEditClientAddress = (): ReturnType<typeof checkSchema> =>
         { current: 'postcode', original: 'existingPostcode' }
       ],
       {
-        summaryMessage: 'Update the client address, update the postcode, or select \'Cancel\'',
+        summaryMessage: 'Update the client address, or select \'Cancel\'',
         inlineMessage: ''
       }
     ),

--- a/src/scripts/controllers/editClientAddressController.ts
+++ b/src/scripts/controllers/editClientAddressController.ts
@@ -1,72 +1,8 @@
 import type { Request, Response, NextFunction } from 'express';
 import { validationResult, type Result } from 'express-validator';
 import { safeString, hasProperty } from '#src/scripts/helpers/index.js';
-import { formatValidationError, type ValidationErrorData } from '#src/scripts/helpers/ValidationErrorHelpers.js';
+import { formatValidationError, handleValidationErrors, type ValidationErrorData } from '#src/scripts/helpers/ValidationErrorHelpers.js';
 import { apiService } from '#src/services/apiService.js';
-
-const BAD_REQUEST = 400;
-
-/**
- * Handles validation errors by rendering the form with error messages
- * @param {Result<ValidationErrorData>} validationErrors - Validation errors from express-validator
- * @param {Request} req - Express request object
- * @param {Response} res - Express response object
- * @param {string} caseReference - Case reference number
- */
-function handleValidationErrors(
-  validationErrors: Result<ValidationErrorData>,
-  req: Request,
-  res: Response,
-  caseReference: string
-): void {
-  // Map validation errors to field names following phone number pattern
-  const resultingErrors = validationErrors.array().map((errorData: ValidationErrorData) => {
-    // Determine field name based on the validation error
-    let fieldName = 'address'; // default
-    
-    if (errorData.summaryMessage.toLowerCase().includes('postcode')) {
-      fieldName = 'postcode';
-    } else if (errorData.summaryMessage.toLowerCase().includes('update the client address')) {
-      // Change detection error - no specific field
-      fieldName = 'address'; // Default to address for summary href
-    }
-    
-    return {
-      fieldName,
-      inlineMessage: errorData.inlineMessage,
-      summaryMessage: errorData.summaryMessage,
-    };
-  });
-
-  // Build input errors object for individual field error messages
-  // Only use inline messages that are not empty
-  const inputErrors = resultingErrors.reduce<Record<string, string>>((acc, { fieldName, inlineMessage }) => {
-    if (inlineMessage.trim() !== '') {
-      acc[fieldName] = inlineMessage;
-    }
-    return acc;
-  }, {});
-
-  // Build error summary list for the error summary component
-  const errorSummaryList = resultingErrors.map(({ summaryMessage, fieldName }) => ({
-    text: summaryMessage,
-    href: `#${fieldName}`,
-  }));
-
-  // Re-render the form with errors and preserve user input
-  res.status(BAD_REQUEST).render('case_details/edit-client-address.njk', {
-    caseReference,
-    currentAddress: hasProperty(req.body, 'address') ? safeString(req.body.address) : '',
-    currentPostcode: hasProperty(req.body, 'postcode') ? safeString(req.body.postcode) : '',
-    existingAddress: hasProperty(req.body, 'existingAddress') ? safeString(req.body.existingAddress) : '',
-    existingPostcode: hasProperty(req.body, 'existingPostcode') ? safeString(req.body.existingPostcode) : '',
-    error: {
-      inputErrors,
-      errorSummaryList
-    },
-    csrfToken: typeof req.csrfToken === 'function' ? req.csrfToken() : undefined,
-  });
-}
 
 /**
  * Renders the edit client address form for a given case reference.

--- a/src/scripts/controllers/editClientAddressController.ts
+++ b/src/scripts/controllers/editClientAddressController.ts
@@ -34,7 +34,7 @@ export async function getEditClientAddress(req: Request, res: Response, next: Ne
       }
     }
     
-    res.render('case_details/edit-client-address.njk', {
+    res.render('case_details/change-client-address.njk', {
       caseReference,
       currentAddress,
       currentPostcode,

--- a/src/scripts/controllers/editClientAddressController.ts
+++ b/src/scripts/controllers/editClientAddressController.ts
@@ -1,0 +1,146 @@
+import type { Request, Response, NextFunction } from 'express';
+import { validationResult, type Result } from 'express-validator';
+import { safeString, hasProperty } from '#src/scripts/helpers/index.js';
+import { formatValidationError, type ValidationErrorData } from '#src/scripts/helpers/ValidationErrorHelpers.js';
+import { apiService } from '#src/services/apiService.js';
+
+const BAD_REQUEST = 400;
+
+/**
+ * Handles validation errors by rendering the form with error messages
+ * @param {Result<ValidationErrorData>} validationErrors - Validation errors from express-validator
+ * @param {Request} req - Express request object
+ * @param {Response} res - Express response object
+ * @param {string} caseReference - Case reference number
+ */
+function handleValidationErrors(
+  validationErrors: Result<ValidationErrorData>,
+  req: Request,
+  res: Response,
+  caseReference: string
+): void {
+  // Map validation errors to field names following phone number pattern
+  const resultingErrors = validationErrors.array().map((errorData: ValidationErrorData) => {
+    // Determine field name based on the validation error
+    let fieldName = 'address'; // default
+    
+    if (errorData.summaryMessage.toLowerCase().includes('postcode')) {
+      fieldName = 'postcode';
+    } else if (errorData.summaryMessage.toLowerCase().includes('update the client address')) {
+      // Change detection error - no specific field
+      fieldName = 'address'; // Default to address for summary href
+    }
+    
+    return {
+      fieldName,
+      inlineMessage: errorData.inlineMessage,
+      summaryMessage: errorData.summaryMessage,
+    };
+  });
+
+  // Build input errors object for individual field error messages
+  // Only use inline messages that are not empty
+  const inputErrors = resultingErrors.reduce<Record<string, string>>((acc, { fieldName, inlineMessage }) => {
+    if (inlineMessage.trim() !== '') {
+      acc[fieldName] = inlineMessage;
+    }
+    return acc;
+  }, {});
+
+  // Build error summary list for the error summary component
+  const errorSummaryList = resultingErrors.map(({ summaryMessage, fieldName }) => ({
+    text: summaryMessage,
+    href: `#${fieldName}`,
+  }));
+
+  // Re-render the form with errors and preserve user input
+  res.status(BAD_REQUEST).render('case_details/edit-client-address.njk', {
+    caseReference,
+    currentAddress: hasProperty(req.body, 'address') ? safeString(req.body.address) : '',
+    currentPostcode: hasProperty(req.body, 'postcode') ? safeString(req.body.postcode) : '',
+    existingAddress: hasProperty(req.body, 'existingAddress') ? safeString(req.body.existingAddress) : '',
+    existingPostcode: hasProperty(req.body, 'existingPostcode') ? safeString(req.body.existingPostcode) : '',
+    error: {
+      inputErrors,
+      errorSummaryList
+    },
+    csrfToken: typeof req.csrfToken === 'function' ? req.csrfToken() : undefined,
+  });
+}
+
+/**
+ * Renders the edit client address form for a given case reference.
+ * @param {Request} req - Express request object
+ * @param {Response} res - Express response object
+ * @param {NextFunction} next - Express next middleware function
+ */
+export async function getEditClientAddress(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const caseReference = safeString(req.params.caseReference);
+  try {
+    const response = await apiService.getClientDetails(req.axiosMiddleware, caseReference);
+    let currentAddress = '';
+    let currentPostcode = '';
+    let existingAddress = '';
+    let existingPostcode = '';
+    
+    if (response.status === 'success' && response.data !== null) {
+      const address = safeString(response.data.address);
+      const postcode = safeString(response.data.postcode);
+      
+      if (address !== '') {
+        currentAddress = address;
+        existingAddress = address;
+      }
+      
+      if (postcode !== '') {
+        currentPostcode = postcode;
+        existingPostcode = postcode;
+      }
+    }
+    
+    res.render('case_details/edit-client-address.njk', {
+      caseReference,
+      currentAddress,
+      currentPostcode,
+      existingAddress,
+      existingPostcode,
+      csrfToken: typeof req.csrfToken === 'function' ? req.csrfToken() : undefined,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * Handles POST request for editing client address form.
+ * Validates input and either displays errors or reloads the page.
+ * @param {Request} req - Express request object
+ * @param {Response} res - Express response object  
+ * @param {NextFunction} next - Express next middleware function
+ */
+export async function postEditClientAddress(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const caseReference = safeString(req.params.caseReference);
+  
+  try {
+    const validationErrors: Result<ValidationErrorData> = validationResult(req).formatWith(formatValidationError);
+    
+    if (!validationErrors.isEmpty()) {
+      handleValidationErrors(validationErrors, req, res, caseReference);
+      return;
+    }
+
+    // No validation errors - save to data service and redirect to client details
+    const address = hasProperty(req.body, 'address') ? safeString(req.body.address) : '';
+    const postcode = hasProperty(req.body, 'postcode') ? safeString(req.body.postcode) : '';
+    
+    await apiService.updateClientDetails(req.axiosMiddleware, caseReference, { 
+      address, 
+      postcode 
+    });
+    
+    res.redirect(`/cases/${caseReference}/client-details`);
+    
+  } catch (error) {
+    next(error);
+  }
+}

--- a/src/scripts/helpers/ValidationErrorHelpers.ts
+++ b/src/scripts/helpers/ValidationErrorHelpers.ts
@@ -88,7 +88,7 @@ export function createChangeDetectionValidator(
        */
       options: (_value: string, meta: Meta): boolean => {
         const { req } = meta;
-        if (req.body === null || req.body === undefined || typeof req.body !== 'object') {
+        if (!isRecord(req.body)) {
           return true;
         }
 

--- a/src/scripts/helpers/ValidationErrorHelpers.ts
+++ b/src/scripts/helpers/ValidationErrorHelpers.ts
@@ -1,4 +1,5 @@
-import type { ValidationError } from 'express-validator';
+import type { ValidationError, Result } from 'express-validator';
+import type { Request, Response } from 'express';
 import { isRecord, hasProperty, safeString } from './dataTransformers.js';
 
 /**
@@ -56,4 +57,68 @@ export function formatValidationError(error: ValidationError): ValidationErrorDa
     summaryMessage: message,
     inlineMessage: message
   };
+}
+
+/**
+ * Handles validation errors by rendering the form with error messages
+ * @param {Result<ValidationErrorData>} validationErrors - Validation errors from express-validator
+ * @param {Request} req - Express request object
+ * @param {Response} res - Express response object
+ * @param {string} caseReference - Case reference number
+ */
+export function handleValidationErrors(
+  validationErrors: Result<ValidationErrorData>,
+  req: Request,
+  res: Response,
+  caseReference: string
+): void {
+  const BAD_REQUEST = 400;
+
+  // Map validation errors to field names following phone number pattern
+  const resultingErrors = validationErrors.array().map((errorData: ValidationErrorData) => {
+    // Determine field name based on the validation error
+    let fieldName = 'address'; // default
+    
+    if (errorData.summaryMessage.toLowerCase().includes('postcode')) {
+      fieldName = 'postcode';
+    } else if (errorData.summaryMessage.toLowerCase().includes('update the client address')) {
+      // Change detection error - no specific field
+      fieldName = 'address'; // Default to address for summary href
+    }
+    
+    return {
+      fieldName,
+      inlineMessage: errorData.inlineMessage,
+      summaryMessage: errorData.summaryMessage,
+    };
+  });
+
+  // Build input errors object for individual field error messages
+  // Only use inline messages that are not empty
+  const inputErrors = resultingErrors.reduce<Record<string, string>>((acc, { fieldName, inlineMessage }) => {
+    if (inlineMessage.trim() !== '') {
+      acc[fieldName] = inlineMessage;
+    }
+    return acc;
+  }, {});
+
+  // Build error summary list for the error summary component
+  const errorSummaryList = resultingErrors.map(({ summaryMessage, fieldName }) => ({
+    text: summaryMessage,
+    href: `#${fieldName}`,
+  }));
+
+  // Re-render the form with errors and preserve user input
+  res.status(BAD_REQUEST).render('case_details/edit-client-address.njk', {
+    caseReference,
+    currentAddress: hasProperty(req.body, 'address') ? safeString(req.body.address) : '',
+    currentPostcode: hasProperty(req.body, 'postcode') ? safeString(req.body.postcode) : '',
+    existingAddress: hasProperty(req.body, 'existingAddress') ? safeString(req.body.existingAddress) : '',
+    existingPostcode: hasProperty(req.body, 'existingPostcode') ? safeString(req.body.existingPostcode) : '',
+    error: {
+      inputErrors,
+      errorSummaryList
+    },
+    csrfToken: typeof req.csrfToken === 'function' ? req.csrfToken() : undefined,
+  });
 }

--- a/src/scripts/helpers/ValidationErrorHelpers.ts
+++ b/src/scripts/helpers/ValidationErrorHelpers.ts
@@ -160,7 +160,7 @@ export function handleValidationErrors(
   }));
 
   // Re-render the form with errors and preserve user input
-  res.status(BAD_REQUEST).render('case_details/edit-client-address.njk', {
+  res.status(BAD_REQUEST).render('case_details/change-client-address.njk', {
     caseReference,
     currentAddress: hasProperty(req.body, 'address') ? safeString(req.body.address) : '',
     currentPostcode: hasProperty(req.body, 'postcode') ? safeString(req.body.postcode) : '',

--- a/tests/e2e/client_details_edit_address.spec.ts
+++ b/tests/e2e/client_details_edit_address.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+
+test('viewing change address form, to see the expected elements', async ({ page }) => {
+  const addressInput = page.locator('#address');
+  const postcodeInput = page.locator('#postcode');
+  const saveButton = page.getByRole('button', { name: 'Save' });
+
+  // Navigate to the `/edit/address`
+  await page.goto('/cases/PC-1922-1879/client-details/edit/address');
+
+  // Expect to see the following elements
+  await expect(page.locator('h1')).toContainText("Client's contact address (optional)");
+  await expect(addressInput).toBeVisible();
+  await expect(postcodeInput).toBeVisible();
+  await expect(saveButton).toBeVisible();
+  
+  // Note: Form pre-population testing requires mock data service configuration
+  // For now, we test the form structure without specific data expectations
+});
+
+test('unchanged fields trigger change detection error (AC5)', async ({ page }) => {
+  const saveButton = page.getByRole('button', { name: 'Save' });
+  const errorSummary = page.locator('.govuk-error-summary');
+
+  // Navigate to the edit form
+  await page.goto('/cases/PC-1922-1879/client-details/edit/address');
+
+  // Fill in form with values and set hidden existing fields to same values
+  // This simulates what would happen when form is pre-populated and user doesn't change anything
+  await page.evaluate(() => {
+    const addressField = document.querySelector('#address') as HTMLInputElement;
+    const postcodeField = document.querySelector('#postcode') as HTMLInputElement;
+    const form = document.querySelector('form');
+    
+    if (addressField && postcodeField && form) {
+      // Set form values
+      addressField.value = 'Test Address';
+      postcodeField.value = 'SW1A 1AA';
+      
+      // Add hidden existing values that match current values (to trigger AC5)
+      const existingAddressInput = document.createElement('input');
+      existingAddressInput.type = 'hidden';
+      existingAddressInput.name = 'existingAddress';
+      existingAddressInput.value = 'Test Address';
+      form.appendChild(existingAddressInput);
+      
+      const existingPostcodeInput = document.createElement('input');
+      existingPostcodeInput.type = 'hidden';
+      existingPostcodeInput.name = 'existingPostcode';
+      existingPostcodeInput.value = 'SW1A 1AA';
+      form.appendChild(existingPostcodeInput);
+    }
+  });
+
+  // Submit form (should trigger AC5 validation error)
+  await expect(saveButton).toBeVisible();
+  await saveButton.click();
+
+  // Check GOV.UK error summary appears for change detection
+  await expect(errorSummary).toBeVisible();
+  await expect(errorSummary).toContainText('There is a problem');
+  await expect(errorSummary).toContainText('Update the client address, update the postcode, or select \'Cancel\'');
+  
+  // AC5 change detection error should NOT have inline field error messages
+  const addressErrorMessage = page.locator('#address-error');
+  const postcodeErrorMessage = page.locator('#postcode-error');
+  await expect(addressErrorMessage).not.toBeVisible();
+  await expect(postcodeErrorMessage).not.toBeVisible();
+});

--- a/tests/e2e/client_details_edit_address.spec.ts
+++ b/tests/e2e/client_details_edit_address.spec.ts
@@ -5,8 +5,8 @@ test('viewing change address form, to see the expected elements', async ({ page 
   const postcodeInput = page.locator('#postcode');
   const saveButton = page.getByRole('button', { name: 'Save' });
 
-  // Navigate to the `/edit/address`
-  await page.goto('/cases/PC-1922-1879/client-details/edit/address');
+  // Navigate to the `/change/address`
+  await page.goto('/cases/PC-1922-1879/client-details/change/address');
 
   // Expect to see the following elements
   await expect(page.locator('h1')).toContainText("Client's contact address (optional)");
@@ -23,7 +23,7 @@ test('unchanged fields trigger change detection error (AC5)', async ({ page }) =
   const errorSummary = page.locator('.govuk-error-summary');
 
   // Navigate to the edit form
-  await page.goto('/cases/PC-1922-1879/client-details/edit/address');
+  await page.goto('/cases/PC-1922-1879/client-details/change/address');
 
   // Submit form (should trigger AC5 validation error)
   await expect(saveButton).toBeVisible();

--- a/tests/e2e/client_details_edit_address.spec.ts
+++ b/tests/e2e/client_details_edit_address.spec.ts
@@ -9,7 +9,7 @@ test('viewing change address form, to see the expected elements', async ({ page 
   await page.goto('/cases/PC-1922-1879/client-details/change/address');
 
   // Expect to see the following elements
-  await expect(page.locator('h1')).toContainText("Client's contact address (optional)");
+  await expect(page.locator('h1')).toContainText("Client address (optional)");
   await expect(addressInput).toBeVisible();
   await expect(postcodeInput).toBeVisible();
   await expect(saveButton).toBeVisible();

--- a/tests/e2e/client_details_edit_address.spec.ts
+++ b/tests/e2e/client_details_edit_address.spec.ts
@@ -25,33 +25,6 @@ test('unchanged fields trigger change detection error (AC5)', async ({ page }) =
   // Navigate to the edit form
   await page.goto('/cases/PC-1922-1879/client-details/edit/address');
 
-  // Fill in form with values and set hidden existing fields to same values
-  // This simulates what would happen when form is pre-populated and user doesn't change anything
-  await page.evaluate(() => {
-    const addressField = document.querySelector('#address') as HTMLInputElement;
-    const postcodeField = document.querySelector('#postcode') as HTMLInputElement;
-    const form = document.querySelector('form');
-    
-    if (addressField && postcodeField && form) {
-      // Set form values
-      addressField.value = 'Test Address';
-      postcodeField.value = 'SW1A 1AA';
-      
-      // Add hidden existing values that match current values (to trigger AC5)
-      const existingAddressInput = document.createElement('input');
-      existingAddressInput.type = 'hidden';
-      existingAddressInput.name = 'existingAddress';
-      existingAddressInput.value = 'Test Address';
-      form.appendChild(existingAddressInput);
-      
-      const existingPostcodeInput = document.createElement('input');
-      existingPostcodeInput.type = 'hidden';
-      existingPostcodeInput.name = 'existingPostcode';
-      existingPostcodeInput.value = 'SW1A 1AA';
-      form.appendChild(existingPostcodeInput);
-    }
-  });
-
   // Submit form (should trigger AC5 validation error)
   await expect(saveButton).toBeVisible();
   await saveButton.click();
@@ -59,7 +32,7 @@ test('unchanged fields trigger change detection error (AC5)', async ({ page }) =
   // Check GOV.UK error summary appears for change detection
   await expect(errorSummary).toBeVisible();
   await expect(errorSummary).toContainText('There is a problem');
-  await expect(errorSummary).toContainText('Update the client address, update the postcode, or select \'Cancel\'');
+  await expect(errorSummary).toContainText('Update the client address, or select \'Cancel\'');
   
   // AC5 change detection error should NOT have inline field error messages
   const addressErrorMessage = page.locator('#address-error');

--- a/tests/unit/middleware/clientAddressSchema.spec.ts
+++ b/tests/unit/middleware/clientAddressSchema.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * Client Address Schema Validation Tests
+ * 
+ * Tests the validation middleware for client address editing.
+ * Validates that validation errors are thrown under the correct circumstances:
+ * - Empty address/postcode handling (optional fields)
+ * - Postcode uppercase conversion
+ * - Change detection (AC5)
+ * 
+ * Testing Level: Unit
+ * Component: Validation Middleware
+ * Dependencies: express-validator, ValidationErrorHelpers
+ */
+
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { validateEditClientAddress } from '#src/middlewares/clientAddressSchema.js';
+import { validationResult } from 'express-validator';
+import { formatValidationError } from '#src/scripts/helpers/ValidationErrorHelpers.js';
+
+// Mock Express request object for testing
+function createMockRequest(bodyData: Record<string, unknown>) {
+  return {
+    body: bodyData
+  } as any;
+}
+
+describe('Client Address Schema Validation', () => {
+  describe('validateEditClientAddress', () => {
+    it('should create validation schema without throwing an error', () => {
+      expect(() => validateEditClientAddress()).to.not.throw();
+    });
+
+    describe('address field validation', () => {
+      it('should pass validation when address is empty (optional field)', async () => {
+        const schema = validateEditClientAddress();
+        const req = createMockRequest({ 
+          address: '', 
+          postcode: '',
+          existingAddress: 'Different St',
+          existingPostcode: 'SW1A 1AA'
+        });
+
+        await Promise.all(schema.map(validation => validation.run(req)));
+        const errors = validationResult(req).formatWith(formatValidationError);
+
+        expect(errors.isEmpty()).to.be.true;
+      });
+
+      it('should pass validation when address contains only whitespace (optional field)', async () => {
+        const testCases = ['   ', '\t\n ', '  \t  '];
+
+        for (const testCase of testCases) {
+          const schema = validateEditClientAddress();
+          const req = createMockRequest({ 
+            address: testCase,
+            postcode: 'SW1A 1AA', // Make a change to avoid AC5 error
+            existingAddress: 'Different St',
+            existingPostcode: 'Different PC'
+          });
+
+          await Promise.all(schema.map(validation => validation.run(req)));
+          const errors = validationResult(req);
+
+          expect(errors.isEmpty(), `Expected validation to pass for address: "${testCase}"`).to.be.true;
+        }
+      });
+
+      it('should pass validation when address is valid', async () => {
+        const validAddresses = [
+          '123 Main Street',
+          'Flat 2, Building Name, Street'
+        ];
+
+        for (const address of validAddresses) {
+          const schema = validateEditClientAddress();
+          const req = createMockRequest({ 
+            address,
+            postcode: 'SW1A 1AA',
+            existingAddress: 'Different St',
+            existingPostcode: 'Different PC'
+          });
+
+          await Promise.all(schema.map(validation => validation.run(req)));
+          const errors = validationResult(req);
+
+          expect(errors.isEmpty(), `Expected validation to pass for: "${address}"`).to.be.true;
+        }
+      });
+
+      it('should trim leading and trailing whitespace from address', async () => {
+        const schema = validateEditClientAddress();
+        const req = createMockRequest({ 
+          address: '  123 Main Street  ',
+          postcode: 'SW1A 1AA',
+          existingAddress: 'Different St',
+          existingPostcode: 'Different PC'
+        });
+
+        await Promise.all(schema.map(validation => validation.run(req)));
+        
+        // Check that address was trimmed
+        expect(req.body.address).to.equal('123 Main Street');
+      });
+    });
+
+    describe('postcode field validation', () => {
+      it('should pass validation when postcode is empty (optional field)', async () => {
+        const schema = validateEditClientAddress();
+        const req = createMockRequest({ 
+          address: '123 Main Street', 
+          postcode: '',
+          existingAddress: 'Different St',
+          existingPostcode: 'SW1A 1AA'
+        });
+
+        await Promise.all(schema.map(validation => validation.run(req)));
+        const errors = validationResult(req).formatWith(formatValidationError);
+
+        expect(errors.isEmpty()).to.be.true;
+      });
+
+      it('should convert postcode to uppercase', async () => {
+        const schema = validateEditClientAddress();
+        const req = createMockRequest({ 
+          address: '123 Main Street',
+          postcode: 'sw1a 1aa',
+          existingAddress: 'Different St',
+          existingPostcode: 'Different PC'
+        });
+
+        await Promise.all(schema.map(validation => validation.run(req)));
+        
+        // Check that postcode was converted to uppercase
+        expect(req.body.postcode).to.equal('SW1A 1AA');
+      });
+
+      it('should pass validation when postcode contains only whitespace (optional field)', async () => {
+        const testCases = ['   ', '\t\n ', '  \t  '];
+
+        for (const testCase of testCases) {
+          const schema = validateEditClientAddress();
+          const req = createMockRequest({ 
+            address: '123 Main Street', // Make a change to avoid AC5 error
+            postcode: testCase,
+            existingAddress: 'Different St',
+            existingPostcode: 'Different PC'
+          });
+
+          await Promise.all(schema.map(validation => validation.run(req)));
+          const errors = validationResult(req);
+
+          expect(errors.isEmpty(), `Expected validation to pass for postcode: "${testCase}"`).to.be.true;
+        }
+      });
+
+      it('should trim leading and trailing whitespace from postcode', async () => {
+        const schema = validateEditClientAddress();
+        const req = createMockRequest({ 
+          address: '123 Main Street',
+          postcode: '  SW1A 1AA  ',
+          existingAddress: 'Different St',
+          existingPostcode: 'Different PC'
+        });
+
+        await Promise.all(schema.map(validation => validation.run(req)));
+        
+        // Check that postcode was trimmed and converted to uppercase
+        expect(req.body.postcode).to.equal('SW1A 1AA');
+      });
+    });
+
+    describe('change detection (AC5)', () => {
+      it('should have validation errors when no changes are made', async () => {
+        const schema = validateEditClientAddress();
+        const req = createMockRequest({ 
+          address: '123 Main Street',
+          postcode: 'SW1A 1AA',
+          existingAddress: '123 Main Street',
+          existingPostcode: 'SW1A 1AA'
+        });
+
+        await Promise.all(schema.map(validation => validation.run(req)));
+        const errors = validationResult(req).formatWith(formatValidationError);
+
+        expect(errors.isEmpty()).to.be.false;
+        
+        const changeError = errors.array().find(error => error.summaryMessage.includes('Update the client address'));
+        expect(changeError).to.exist;
+        expect(changeError?.summaryMessage).to.equal('Update the client address, update the postcode, or select \'Cancel\'');
+      });
+
+      it('should pass validation when address changes', async () => {
+        const schema = validateEditClientAddress();
+        const req = createMockRequest({ 
+          address: '456 New Street',
+          postcode: 'SW1A 1AA',
+          existingAddress: '123 Main Street',
+          existingPostcode: 'SW1A 1AA'
+        });
+
+        await Promise.all(schema.map(validation => validation.run(req)));
+        const errors = validationResult(req);
+
+        expect(errors.isEmpty()).to.be.true;
+      });
+
+      it('should pass validation when postcode changes', async () => {
+        const schema = validateEditClientAddress();
+        const req = createMockRequest({ 
+          address: '123 Main Street',
+          postcode: 'W1A 0AX',
+          existingAddress: '123 Main Street',
+          existingPostcode: 'SW1A 1AA'
+        });
+
+        await Promise.all(schema.map(validation => validation.run(req)));
+        const errors = validationResult(req);
+
+        expect(errors.isEmpty()).to.be.true;
+      });
+
+      it('should handle whitespace differences in change detection', async () => {
+        const schema = validateEditClientAddress();
+        const req = createMockRequest({ 
+          address: ' 123 Main Street ',
+          postcode: ' SW1A 1AA ',
+          existingAddress: '123 Main Street',
+          existingPostcode: 'SW1A 1AA'
+        });
+
+        await Promise.all(schema.map(validation => validation.run(req)));
+        const errors = validationResult(req).formatWith(formatValidationError);
+
+        // Should detect as unchanged after trimming
+        expect(errors.isEmpty()).to.be.false;
+        
+        const changeError = errors.array().find(error => error.summaryMessage.includes('Update the client address'));
+        expect(changeError).to.exist;
+      });
+    });
+
+    describe('error structure validation', () => {
+      it('should produce correctly formatted errors when used with formatValidationError', async () => {
+        const schema = validateEditClientAddress();
+        const req = createMockRequest({ 
+          address: '123 Main Street',  // No change to trigger AC5 error
+          postcode: 'SW1A 1AA',
+          existingAddress: '123 Main Street',
+          existingPostcode: 'SW1A 1AA'
+        });
+
+        await Promise.all(schema.map(validation => validation.run(req)));
+        const errors = validationResult(req).formatWith(formatValidationError);
+
+        expect(errors.isEmpty()).to.be.false;
+        
+        const errorData = errors.array()[0];
+        expect(errorData).to.have.property('summaryMessage');
+        expect(errorData).to.have.property('inlineMessage');
+        expect(errorData.summaryMessage).to.be.a('string');
+        expect(errorData.inlineMessage).to.be.a('string');
+      });
+    });
+  });
+});

--- a/tests/unit/middleware/clientAddressSchema.spec.ts
+++ b/tests/unit/middleware/clientAddressSchema.spec.ts
@@ -187,7 +187,7 @@ describe('Client Address Schema Validation', () => {
         
         const changeError = errors.array().find(error => error.summaryMessage.includes('Update the client address'));
         expect(changeError).to.exist;
-        expect(changeError?.summaryMessage).to.equal('Update the client address, update the postcode, or select \'Cancel\'');
+        expect(changeError?.summaryMessage).to.equal('Update the client address, or select \'Cancel\'');
       });
 
       it('should pass validation when address changes', async () => {

--- a/views/case_details/_client-details-partial.njk
+++ b/views/case_details/_client-details-partial.njk
@@ -192,7 +192,7 @@
       actions: {
         items: [
           {
-            href: "/cases/" + data.caseReference + "/client-details/edit/address",
+            href: "/cases/" + data.caseReference + "/client-details/change/address",
             text: "Change",
             visuallyHiddenText: "Change Address"
           }

--- a/views/case_details/_client-details-partial.njk
+++ b/views/case_details/_client-details-partial.njk
@@ -192,7 +192,7 @@
       actions: {
         items: [
           {
-            href: "/",
+            href: "/cases/" + data.caseReference + "/client-details/edit/address",
             text: "Change",
             visuallyHiddenText: "Change Address"
           }

--- a/views/case_details/_client-details-partial.njk
+++ b/views/case_details/_client-details-partial.njk
@@ -37,9 +37,11 @@
   {% if address %}
     {{ address }}
     {% if postcode %}
-      <br>
-      {{ postcode }}
+        <br>
     {% endif %}
+  {% endif %}
+  {% if postcode %}
+    {{ postcode }}  
   {% endif %}
 {% endmacro %}
 

--- a/views/case_details/change-client-address.njk
+++ b/views/case_details/change-client-address.njk
@@ -33,7 +33,7 @@
         <input type="hidden" name="existingAddress" value="{{ existingAddress | default(currentAddress) }}">
         <input type="hidden" name="existingPostcode" value="{{ existingPostcode | default(currentPostcode) }}">
         
-        <h1 class="govuk-heading-l">Client's contact address (optional)</h1>
+        <h1 class="govuk-heading-l">Client address (optional)</h1>
         
         {{ govukTextarea({
           label: {

--- a/views/case_details/change-client-address.njk
+++ b/views/case_details/change-client-address.njk
@@ -28,7 +28,7 @@
         {% endif %}
         {{ errorSummary(error.errorSummaryList) }}
       {% endif %}
-      <form method="post" action="/cases/{{ caseReference }}/client-details/edit/address">
+      <form method="post" action="/cases/{{ caseReference }}/client-details/change/address">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         <input type="hidden" name="existingAddress" value="{{ existingAddress | default(currentAddress) }}">
         <input type="hidden" name="existingPostcode" value="{{ existingPostcode | default(currentPostcode) }}">

--- a/views/case_details/edit-client-address.njk
+++ b/views/case_details/edit-client-address.njk
@@ -1,0 +1,72 @@
+{% extends "base.njk" %}
+
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "components/errorSummaryComponent.njk" import errorSummary %}
+
+{% set backLinkHref = "/cases/" + caseReference + "/client-details" %}
+
+{% block backLink %}
+  {{ govukBackLink({
+      text: "Back",
+      href: backLinkHref,
+      classes: "govuk-!-margin-bottom-0"
+    }) }}
+{% endblock %}
+
+{% block pageContent %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if error %}
+        {% if error.inputErrors.address %}
+          {% set addressErrorMessage = { text: error.inputErrors.address } %}
+        {% endif %}
+        {% if error.inputErrors.postcode %}
+          {% set postcodeErrorMessage = { text: error.inputErrors.postcode } %}
+        {% endif %}
+        {{ errorSummary(error.errorSummaryList) }}
+      {% endif %}
+      <form method="post" action="/cases/{{ caseReference }}/client-details/edit/address">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        <input type="hidden" name="existingAddress" value="{{ existingAddress | default(currentAddress) }}">
+        <input type="hidden" name="existingPostcode" value="{{ existingPostcode | default(currentPostcode) }}">
+        
+        <h1 class="govuk-heading-l">Client's contact address (optional)</h1>
+        
+        {{ govukTextarea({
+          label: {
+            text: "Address",
+            classes: "govuk-label--m"
+          },
+          id: "address",
+          name: "address",
+          value: currentAddress,
+          errorMessage: addressErrorMessage,
+          autocomplete: "off"
+        }) }}
+        
+        {{ govukInput({
+          label: {
+            text: "Postcode",
+            classes: "govuk-label--m"
+          },
+          id: "postcode",
+          name: "postcode",
+          classes: "govuk-input--width-10",
+          value: currentPostcode,
+          errorMessage: postcodeErrorMessage,
+          autocomplete: "off"
+        }) }}
+        
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Save"
+          }) }}
+          <a class="govuk-link" href="{{ backLinkHref }}">Cancel</a>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
[EL-2382](https://dsdmoj.atlassian.net/jira/software/c/projects/EL/boards/1449?selectedIssue=EL-2458)

## What changed and Why?

I have added a contact address editing feature that allows users to modify client address and postcode details with light validation:

Added:

- New validation schema clientAddressSchema.ts with minimal but effective validation rules including postcode uppercase conversion and change detection 
 - New controller editClientAddressController.ts with GET/POST handlers for address editing, including API integration for fetching and updating client details
 - New template edit-client-address.njk following GOV.UK Design System patterns with proper error handling
 - Type-safe error handling using TypedValidationError class for structured validation messages
 -  API service integration to fetch existing client data and persist address changes
 - Test coverage including unit tests for validation schema and e2e tests for form functionality
 
 This implements the user story requirement to allow legal advisers to edit client contact addresses with proper validation, ensuring data integrity and following established patterns in the codebase.

## Checklist

Before you ask people to review this PR:

- [x] **Tests and linting** are passing.  
- [x] **Branch is up to date** with `main` (no merge conflicts).  
- [x] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [x] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [x] **Diff has been checked** for any unexpected changes.  
- [x] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.

[EL-2382]: https://dsdmoj.atlassian.net/browse/EL-2382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ