### PR TITLE
EL-2591: Update image used in Publish documentation GitHub Action Workflow - Part 3

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -39,9 +39,9 @@ jobs:
           mv docs/* .
           rm -rf docs
       - name: Compile Markdown to HTML and create artifact
-        # Script to deploy is not in the repo, but in this image: `ministryofjustice/tech-docs-github-pages-publisher:v3`
+        # Not in this repo, but in this image: `ministryofjustice/tech-docs-github-pages-publisher:v4.0.0`
         run: |
-          /scripts/deploy.sh
+          /usr/local/bin/package
       - name: Upload artifact to be published
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-2591)

## What changed and Why?

- If applied, this updates this command to compile HTML and artifacts for technical documents

## Guidance to review (optional)

- This follows the pattern as found in this repo: https://github.com/ministryofjustice/hmpps-integration-api-docs/blob/5e6b7a1484d13072a5030cee2a6bace1aee9a526/.github/workflows/publish.yml#L25

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.