### PR TITLE
EL-2591: Update image used in Publish documentation GitHub Action Workflow - Part 4

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   build:
+    name: Build application
     runs-on: ubuntu-latest
     container:
       image: ministryofjustice/tech-docs-github-pages-publisher:v4.0.0
@@ -32,12 +33,6 @@ jobs:
           sparse-checkout: |
             docs
           sparse-checkout-cone-mode: false
-      # We move the docs directory to the root so it is treated as if the docs directory was
-      # the only thing in the repository.
-      - name: Move directory to root
-        run: |
-          mv docs/* .
-          rm -rf docs
       - name: Compile Markdown to HTML and create artifact
         # Not in this repo, but in this image: `ministryofjustice/tech-docs-github-pages-publisher:v4.0.0`
         run: |


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-2591)

## What changed and Why?

- If applied, this leaves the project structure as is (as in does not move directory to root), which should hopefully mean the CSS is picked up by the next action

## Guidance to review (optional)

- This follows the pattern as found in this repo: https://github.com/ministryofjustice/hmpps-integration-api-docs/blob/5e6b7a1484d13072a5030cee2a6bace1aee9a526/.github/workflows/publish.yml#L25

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.