### PR TITLE
EL-2591: Update image used in Publish documentation GitHub Action Workflow - Part 5

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -18,25 +18,31 @@ concurrency:
 
 jobs:
   build:
-    name: Build application
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v4.0.0
+      image: ministryofjustice/tech-docs-github-pages-publisher:v3
     permissions:
       contents: read
     steps:
       # We only checkout the docs directory, which allows us to keep all necessary files for
       # generating the docs separate from the app.
       - name: Checkout
-        uses: actions/checkout@v5
+        # updating to `actions/checkout@v5` had compatibility issues with the base image (EL-2591)
+        uses: actions/checkout@v4 
         with:
           sparse-checkout: |
             docs
           sparse-checkout-cone-mode: false
-      - name: Compile Markdown to HTML and create artifact
-        # Not in this repo, but in this image: `ministryofjustice/tech-docs-github-pages-publisher:v4.0.0`
+      # We move the docs directory to the root so it is treated as if the docs directory was
+      # the only thing in the repository.
+      - name: Move directory to root
         run: |
-          /usr/local/bin/package
+          mv docs/* .
+          rm -rf docs
+      - name: Compile Markdown to HTML and create artifact
+        # Script to deploy is not in the repo, but in this image: `ministryofjustice/tech-docs-github-pages-publisher:v3`
+        run: |
+          /scripts/deploy.sh
       - name: Upload artifact to be published
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-2591)

## What changed and Why?

- If applied, this reverts the changes and leaves a note as to why we have left it at `actions/checkout@v4` on the  'Publish documentation' github action workflow.

## Guidance to review (optional)

- n/a

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.