### PR TITLE
EL-2592: adding frontend js file for checkout version v5

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -20,15 +20,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v3
+      image: ministryofjustice/tech-docs-github-pages-publisher:v6.0.1
     permissions:
       contents: read
     steps:
       # We only checkout the docs directory, which allows us to keep all necessary files for
       # generating the docs separate from the app.
       - name: Checkout
-        # updating to `actions/checkout@v5` had compatibility issues with the base image (EL-2591)
-        uses: actions/checkout@v4 
+        # Updated to actions/checkout@v5 with compatible v6.0.1 publisher image (EL-2592)
+        uses: actions/checkout@v5 
         with:
           sparse-checkout: |
             docs

--- a/docs/source/javascripts/govuk_frontend.js
+++ b/docs/source/javascripts/govuk_frontend.js
@@ -1,0 +1,1 @@
+//= require govuk_frontend_all

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -104,6 +104,7 @@ export default [
       'tests/**/*.spec.ts',
       'tests/helpers/*', // Test helper utilities
       'docs/source/javascripts/application.js', // Parsing error this file was not found by the project service. Consider either including it in the `tsconfig.json` or including it in `allowDefaultProject`
+      'docs/source/javascripts/govuk_frontend.js', // Documentation JavaScript file, not part of main TypeScript project
       'eslint.config.js', // Parsing error this file was not found by the project service. Consider either including it in the `tsconfig.json` or including it in `allowDefaultProject`,
       'coverage', // Ignore the code coverage output from linter
       'scripts/e2e_coverage/*' // Route coverage analysis scripts


### PR DESCRIPTION
[EL-2592](https://dsdmoj.atlassian.net/browse/EL-2592)

## What changed and Why?
### Problem
EL-2592: GitHub Actions workflow failed when attempting to upgrade from actions/checkout@v4 to @v5, causing pthread_getname_np: symbol not found errors due to Node.js compatibility issues between checkout@v5 and the outdated publisher Docker image.

### Root Cause Analysis
actions/checkout@v5 requires Node.js 20+
Current ministryofjustice/tech-docs-github-pages-publisher:v3 uses outdated Node.js incompatible with checkout@v5
Publisher v5.0.0+ introduced breaking changes requiring new JavaScript files
### **Solution**
Implemented systematic two-component upgrade:

1. **Updated GitHub Actions workflow** (publish-documentation.yml):
   - Upgraded `actions/checkout@v4` → `@v5` 
   - Upgraded `ministryofjustice/tech-docs-github-pages-publisher:v3` → `:v6.0.1`
   - Updated comment explaining the fix

2. **Added required dependency** (govuk_frontend.js):
   - Required by publisher v6 for GOV.UK Frontend v5 compatibility
   - Simple one-line file: `//= require govuk_frontend_all`

3. **Fixed ESLint configuration** (eslint.config.js):
   - Added ignore rule for govuk_frontend.js
   - Prevents TypeScript linting errors on documentation files
## Checklist

Before you ask people to review this PR:

- [x] **Tests and linting** are passing.  
- [x] **Branch is up to date** with `main` (no merge conflicts).  
- [x] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [x] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [x] **Diff has been checked** for any unexpected changes.  
- [x] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.

[EL-2592]: https://dsdmoj.atlassian.net/browse/EL-2592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ