### PR TITLE
fix: correct Docker image version from v6.0.1 to v4.0.0

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -20,14 +20,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:v6.0.1
+      image: ministryofjustice/tech-docs-github-pages-publisher:v4.0.0
     permissions:
       contents: read
     steps:
       # We only checkout the docs directory, which allows us to keep all necessary files for
       # generating the docs separate from the app.
       - name: Checkout
-        # Updated to actions/checkout@v5 with compatible v6.0.1 publisher image (EL-2592)
+        # Updated to actions/checkout@v5 with compatible v4.0.0 publisher image (EL-2592)
         uses: actions/checkout@v5 
         with:
           sparse-checkout: |


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-XXX)

## What changed and Why?

The v6 docker image used in PR #235 didn't actually exist on dockerhub. So this uses the v4 docker image instead.

## Checklist

Before you ask people to review this PR:

- [x] **Tests and linting** are passing.  
- [x] **Branch is up to date** with `main` (no merge conflicts).  
- [x] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [x] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [x] **Diff has been checked** for any unexpected changes.  
- [x] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.