### PR TITLE
Fix deployment script path for v4.0.0 publisher image

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -40,9 +40,9 @@ jobs:
           mv docs/* .
           rm -rf docs
       - name: Compile Markdown to HTML and create artifact
-        # Script to deploy is not in the repo, but in this image: `ministryofjustice/tech-docs-github-pages-publisher:v3`
+        # Script to deploy is not in the repo, but in this image: `ministryofjustice/tech-docs-github-pages-publisher:v4.0.0`
         run: |
-          /scripts/deploy.sh
+          /usr/local/bin/package
       - name: Upload artifact to be published
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
- Updated script path from /scripts/deploy.sh to /usr/local/bin/package
- v4.0.0+ publisher images use /usr/local/bin/package instead of /scripts/deploy.sh
- Part of EL-2592: Update to actions/checkout@v5

[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-XXX)

## What changed and Why?

following on from #236, the deploy script is no longer available so using /bin/package isntead

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.