### PR TITLE
EL-2630 Updates passphraseContent logic in the UI

### DIFF
--- a/views/case_details/_client-details-partial.njk
+++ b/views/case_details/_client-details-partial.njk
@@ -49,10 +49,10 @@
 {% set addressWithPostcodeThirdParty = renderAddress(data.thirdParty.address, data.thirdParty.postcode) %}
 
 {% set passphraseContent %}
-  {% if data.thirdParty.passphraseSetUp %}
-    {{ data.thirdParty.passphrase }}
+  {% if data.thirdParty.passphraseSetUp.selected[0] === "Yes" %}
+    {{ data.thirdParty.passphraseSetUp.passphrase }}
   {% else %}
-    {{ t('forms.clientDetails.thirdParty.passphraseNotSetUp', {reason: data.thirdParty.passphraseNotSetUpReason}) }}
+    {{ data.thirdParty.passphraseSetUp.selected[0] }}
   {% endif %}
 {% endset %}
 


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-2630)

## What changed and Why?
This pull request updates the logic for displaying third-party passphrase details in the client details partial. The change makes the rendering more robust by checking the selected value for passphrase setup and correctly displaying either the passphrase or the selected option.

Improvements to passphrase display logic:

* Updated the conditional to check `data.thirdParty.passphraseSetUp.selected[0] === "Yes"` instead of just `data.thirdParty.passphraseSetUp`, ensuring the passphrase is only shown when setup is confirmed.
* Changed the displayed value in the "else" branch to show the selected option directly instead of a translated reason, simplifying the output.

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.