### PR TITLE
EL-3140: Update follow redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "immutable": "^5.1.5",
     "qs": "6.14.2",
     "flatted": "^3.4.2",
-    "picomatch": "^2.3.2"
+    "picomatch": "^2.3.2",
+    "follow-redirects": "^1.16.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,13 +3813,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-3140)

## What changed and Why?

Bumps follow-redirects from 1.15.11 to 1.16.0.

## Guidance to review (optional)

Resolves this [PR](https://github.com/ministryofjustice/laa-manage-your-civil-cases/pull/660)

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.