### PR TITLE
EL-3136: Update sca config to disable yarn audit

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -25,9 +25,10 @@ jobs:
 
     steps:
       - name: Run, SCA - Software Composition Analysis
-        uses: ministryofjustice/devsecops-actions/sca@f965eb1771ec66cfc41d7d57dc607fa6dfbc10ed # v1.4.0
+        uses: ministryofjustice/devsecops-actions/sca@86248cec9a6bb1fd4dabc08a05178e0650d3af4f # Feature branch
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
           # Custom Configuration - CodeQL wants to upload SARIF file and so does this workflow. Keeping CodeQL behaviour.
           codeql-upload-findings: "never"
+          disable-yarn-audit: "true"


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-3136)

## What changed and Why?

config updated to use temporary hash and yarn audit diabled. 

## Guidance to review (optional)

Follows this [discussion](https://mojdt.slack.com/archives/C0A1Q3HQ8LW/p1776095510822779)

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.