### PR TITLE
EL-3182:  Add missing label to `providerNote`

### DIFF
--- a/views/case_details/_case-details-partial.njk
+++ b/views/case_details/_case-details-partial.njk
@@ -186,23 +186,25 @@
 {% endif %}
 
 {% block formContent %}
-
-  <h3 class="govuk-heading-s govuk-!-margin-bottom-3 govuk-!-margin-top-6">{{ t('pages.caseDetails.caseDetailsSection.noteLabel') }}</h3>
-
   <form method="post" action="">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukCharacterCount({
-        id: "providerNote",
-        name: "providerNote",
-        value: currentProviderNote,
-        errorMessage: errorMessages.providerNote if error,
-        maxlength: maxProviderNoteLength,
-        threshold: characterThreshold,
-        formGroup: { classes: "govuk-!-margin-bottom-0" }
-      }) }}
+      id: "providerNote",
+      name: "providerNote",
+      label: {
+          text: t('pages.caseDetails.caseDetailsSection.noteLabel'),
+          classes: "govuk-label--s govuk-!-margin-top-6 govuk-!-margin-bottom-3",
+          isPageHeading: false
+      },
+      value: currentProviderNote,
+      errorMessage: errorMessages.providerNote if error,
+      maxlength: maxProviderNoteLength,
+      threshold: characterThreshold,
+      formGroup: { classes: "govuk-!-margin-bottom-0" }
+    }) }}
 
     {{ govukButton({
-        text: t('common.save')
-      }) }}
+      text: t('common.save')
+    }) }}
   </form>
 {% endblock %}


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-3182)

## What changed and Why?

- If applied, this updates the `providerNote` text box to have a label

## Guidance to review (optional)

- n/a

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.