### PR TITLE
EL-3215: Sortable column headers broken at high zoom

### DIFF
--- a/src/scss/components/_sortable-table.scss
+++ b/src/scss/components/_sortable-table.scss
@@ -1,23 +1,20 @@
 [aria-sort="ascending"] a,
 [aria-sort="descending"] a {
+  align-items: center;
+  gap: 4px;
   position: relative;
-  margin-right: 15px;
 }
 
-[aria-sort="descending"] a:after {
-  content: " ▼";
+[aria-sort="descending"] a::after {
+  content: "▼";
   font-size: 0.8em;
-  position: absolute;
-  right: -15px;
-  top: 2px;
+  flex-shrink: 0;
 }
 
-[aria-sort="ascending"] a:after {
-  content: " ▲";
+[aria-sort="ascending"] a::after {
+  content: "▲";
   font-size: 0.8em;
-  position: absolute;
-  right: -15px;
-  top: 2px;
+  flex-shrink: 0;
 }
 
 .stack-case-flags {


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-3215)

## What changed and Why?

- If applied, this stops the clipping of the arrow on the table when zoomed in.

## Guidance to review (optional)

- This is all custom CSS so was able to adjust it, instead of reverting to using the [Sortable table](https://design-patterns.service.justice.gov.uk/components/sortable-table/)

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.