### PR TITLE
EXAMPLE: PR with login callback for UAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ## This repository is built upon the [GOV.UK Frontend Express Skeleton](https://github.com/ministryofjustice/govuk-frontend-express) and has created the [LAA Express TypeScript Template (ETT)](https://github.com/ministryofjustice/laa-express-typescript-template)
 [![Standards Icon]][Standards Link]
 
+
 ![govuk-frontend 5.10.2](https://img.shields.io/badge/govuk--frontend%20version-5.10.2-005EA5?logo=gov.uk&style=flat)
 
 ## Quick Start

--- a/deploy/laa-manage-your-civil-cases/values/uat.yaml
+++ b/deploy/laa-manage-your-civil-cases/values/uat.yaml
@@ -94,8 +94,8 @@ env:
   API_PREFIX: "/cla_provider/api/v1"
   REDIS_ENABLED: true
   REDIS_TLS_ENABLED: true
-  ENTRA_REDIRECT_URI: "https://main-manage-your-civil-cases-uat.cloud-platform.service.justice.gov.uk/auth/callback" # This will need to be adjusted for the UAT branch you're on and allow it on `https://github.com/ministryofjustice/staff-identity-idam-entra-infra/blob/main/terraform/envs/nleexternal/laa-mcc/main.tf#L55`
-  ENTRA_POST_LOGOUT_REDIRECT_URI: "https://main-manage-your-civil-cases-uat.cloud-platform.service.justice.gov.uk/auth/logout/callback" # This will need to be adjusted for the UAT branch you're on and allow it on `https://github.com/ministryofjustice/staff-identity-idam-entra-infra/blob/main/terraform/envs/nleexternal/laa-mcc/main.tf#L54`
+  ENTRA_REDIRECT_URI: "http://example-pr-with-lo-mcc-uat.cloud-platform.service.justice.gov.uk/auth/callback" # This will need to be adjusted for the UAT branch you're on and allow it on `https://github.com/ministryofjustice/staff-identity-idam-entra-infra/blob/main/terraform/envs/nleexternal/laa-mcc/main.tf#L55`
+  ENTRA_POST_LOGOUT_REDIRECT_URI: "http://example-pr-with-lo-mcc-uat.cloud-platform.service.justice.gov.uk/auth/logout/callback" # This will need to be adjusted for the UAT branch you're on and allow it on `https://github.com/ministryofjustice/staff-identity-idam-entra-infra/blob/main/terraform/envs/nleexternal/laa-mcc/main.tf#L54`
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## Template Pull Request

This is a template to show how to create a PR with its own UAT link that can be logged in without having to copy the callback state into a new browser tab. That is an ugly hack that non-devs shouldn't have to worry about, so this PR and the `staff-identity-idam-entra-infra` one linked below both set the example of how to do this.

Steps followed:
1. Create your PR.
  - For this example, a single blank line has been added to the Readme file so that the PR can be created.
2. Check the UAT link from the helm deployment.
  - In this PR, it is: http://example-pr-with-lo-mcc-uat.cloud-platform.service.justice.gov.uk/
3. Add that UAT link to the staff-identity-idam-entra-infra. Example for this PR:
  - https://github.com/ministryofjustice/staff-identity-idam-entra-infra/pull/623
 4. Add that UAT link to the config yml file for this PR.
  - This kicks off a second deployment of this PR. When that's done and the staff-identity-idam-entra-infra PR is deployed, it should be good to go.