### PR TITLE
EL-3297: Update actions cache to 6.1.0

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -81,7 +81,7 @@ jobs:
           name: docker-builder
 
       - name: Cache Docker layers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/reusable-playwright-steps
 
       - name: Cache Playwright browsers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-3297)

## What changed and Why?

Actions cache updated to 6.1.0

## Guidance to review (optional)

Resolves this [PR](https://github.com/ministryofjustice/laa-manage-your-civil-cases/pull/773)

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.