### PR TITLE
EL-3235: Build state relay into the auth flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "morgan": "~1.11.0",
     "nunjucks": "^3.2.4",
     "redis": "^5.12.1",
-    "socket.io": "^4.8.3"
+    "socket.io": "^4.8.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/src/scripts/controllers/loginController.ts
+++ b/src/scripts/controllers/loginController.ts
@@ -5,6 +5,8 @@ import config from '#config.js';
 import { HTTP } from '#src/services/api/base/constants.js';
 import { randomUUID } from 'node:crypto';
 import { getSilasLoginUrl, exchangeSilasCodeForToken, getSilasLogoutUrl, SilasIdentityMappingError } from '#src/services/silasAuthService.js';
+import { createRelayState, isAllowedRelayTarget, parseRelayState, verifyRelayState } from '#utils/server/auth.relay.js';
+import { handleRelay } from '#src/scripts/helpers/auth.js';
 
 /**
  * Generates a random CSRF-style state value for the SiLAS auth redirect flow.
@@ -35,7 +37,10 @@ function renderLoginError(res: Response, error: string, status: number): void {
  * @returns {Promise<void>}
  */
 export async function startSilasLogin(req: Request, res: Response): Promise<void> {
-  const state = generateState();
+  const state = req.hostname !== new URL(config.silas.redirectUri).hostname ?
+    createRelayState(randomUUID(), `https://${req.hostname}`, config.session.secret) :
+    generateState();
+  
   req.session.silasLoginState = state;
 
   try {
@@ -64,6 +69,11 @@ export async function startSilasLogin(req: Request, res: Response): Promise<void
 export async function handleSilasCallback(req: Request, res: Response): Promise<void> {
   const code = typeof req.query.code === 'string' ? req.query.code : '';
   const state = typeof req.query.state === 'string' ? req.query.state : '';
+
+  // exit early if callback is relayed to ephemeral env
+  if (handleRelay({ code, state }, req, res)) {
+    return;
+  }
 
   if (!code || !state || state !== req.session.silasLoginState) {
     renderLoginError(res, 'Invalid authentication callback.', HTTP.BAD_REQUEST);

--- a/src/scripts/controllers/loginController.ts
+++ b/src/scripts/controllers/loginController.ts
@@ -5,8 +5,8 @@ import config from '#config.js';
 import { HTTP } from '#src/services/api/base/constants.js';
 import { randomUUID } from 'node:crypto';
 import { getSilasLoginUrl, exchangeSilasCodeForToken, getSilasLogoutUrl, SilasIdentityMappingError } from '#src/services/silasAuthService.js';
-import { createRelayState, isAllowedRelayTarget, parseRelayState, verifyRelayState } from '#utils/server/auth.relay.js';
-import { handleRelay } from '#src/scripts/helpers/auth.js';
+import { createRelayState } from '#utils/server/index.js';
+import { handleRelay } from '#src/scripts/helpers/index.js';
 
 /**
  * Generates a random CSRF-style state value for the SiLAS auth redirect flow.

--- a/src/scripts/helpers/auth.ts
+++ b/src/scripts/helpers/auth.ts
@@ -1,0 +1,47 @@
+import type { Request, Response } from 'express';
+import '#src/scripts/helpers/sessionHelpers.js';
+import config from '#config.js';
+import { HTTP } from '#src/services/api/base/constants.js';
+import { isAllowedRelayTarget, parseRelayState, verifyRelayState } from '#utils/server/auth.relay.js';
+
+/**
+ * If the state encodes a signed relay target for a different host, validates
+ * the signature and redirects the callback to that ephemeral environment.
+ * @param {object} data - The parsed auth code response.
+ * @param {string} data.code - The authorisation code from Entra.
+ * @param {string} data.state - The OAuth state parameter.
+ * @param {Request} req - The Express request.
+ * @param {Response} res - The Express response.
+ * @returns {boolean} true if the response was handled (redirected or rejected), false if
+ *          the callback should be processed locally.
+ */
+export function handleRelay(
+  data: { code: string; state: string },
+  req: Request,
+  res: Response,
+): boolean {
+  const relayState = parseRelayState(data.state);
+  if (relayState === null) return false;
+
+  const { target } = relayState;
+  if (
+    !verifyRelayState(relayState, config.session.secret) ||
+    !isAllowedRelayTarget(target)
+  ) {
+    res.status(HTTP.BAD_REQUEST).send("Invalid relay target");
+    return true;
+  }
+
+  const targetUrl = new URL(target);
+  if (targetUrl.hostname === req.hostname) {
+    return false;
+  }
+
+  targetUrl.pathname = "/auth/callback";
+  targetUrl.searchParams.set("code", data.code);
+  targetUrl.searchParams.set("state", data.state);
+
+  res.set("Cache-Control", "no-store");
+  res.redirect(targetUrl.toString());
+  return true;
+}

--- a/src/scripts/helpers/index.ts
+++ b/src/scripts/helpers/index.ts
@@ -130,3 +130,7 @@ export {
   fetchProviderNameAndDetail,
   hasMoreThanOneCategory
 } from './providerDetailHelper.js';
+
+export {
+  handleRelay
+} from './auth.js';

--- a/tests/unit/controllers/loginController.spec.ts
+++ b/tests/unit/controllers/loginController.spec.ts
@@ -1,0 +1,198 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import type { Request, Response } from 'express';
+import { ConfidentialClientApplication } from '@azure/msal-node';
+
+import { handleSilasCallback } from '#src/scripts/controllers/loginController.js';
+import config from '#config.js';
+import { HTTP } from '#src/services/api/base/constants.js';
+import { SilasIdentityMappingError } from '#src/services/silasAuthService.js';
+import { createRelayState } from '#utils/server/auth.relay.js';
+
+function toBase64Url(value: string): string {
+	return Buffer.from(value).toString('base64url');
+}
+
+function normalizeScope(scope: string): string {
+	if (!scope.includes('/')) {
+		return scope;
+	}
+
+	const segments = scope.split('/').filter(Boolean);
+	return segments[segments.length - 1] ?? scope;
+}
+
+function buildAccessToken(claimOverrides: Record<string, unknown> = {}): string {
+	const apiScope = config.silas.scopes
+		.find((scope) => !['openid', 'profile', 'offline_access'].includes(scope.toLowerCase()));
+
+	const claims = {
+		iss: `https://login.microsoftonline.com/${config.silas.tenantId}/v2.0`,
+		aud: config.silas.expectedAudience,
+		scp: apiScope !== undefined ? normalizeScope(apiScope) : 'openid',
+		preferred_username: 'user@example.test',
+		oid: 'user-oid',
+		...claimOverrides,
+	};
+
+	return [
+		toBase64Url(JSON.stringify({ alg: 'none', typ: 'JWT' })),
+		toBase64Url(JSON.stringify(claims)),
+		'signature',
+	].join('.');
+}
+
+describe('Login Controller', () => {
+	let req: Partial<Request> & { session: Record<string, unknown> };
+	let res: Partial<Response> & { render: sinon.SinonStub; redirect: sinon.SinonStub; send: sinon.SinonStub; set: sinon.SinonStub; status: sinon.SinonStub };
+	let regenerateStub: sinon.SinonStub;
+	let saveStub: sinon.SinonStub;
+	let acquireTokenByCodeStub: sinon.SinonStub;
+
+	beforeEach(() => {
+		regenerateStub = sinon.stub().callsFake((callback: (error?: Error | null) => void) => {
+			callback(null);
+		});
+		saveStub = sinon.stub().callsFake((callback: (error?: Error | null) => void) => {
+			callback(null);
+		});
+
+		req = {
+			hostname: 'app.example.test',
+			session: {
+				silasLoginState: 'expected-state',
+				regenerate: regenerateStub,
+				save: saveStub,
+			} as any,
+		};
+
+		res = {
+			render: sinon.stub(),
+			redirect: sinon.stub() as sinon.SinonStub,
+			send: sinon.stub(),
+			set: sinon.stub(),
+			status: sinon.stub().returnsThis(),
+		};
+
+		acquireTokenByCodeStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByCode');
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	describe('handleSilasCallback', () => {
+		it('renders an error when the callback state is invalid', async () => {
+			req.query = { code: 'auth-code', state: 'unexpected-state' };
+
+			await handleSilasCallback(req as Request, res as Response);
+
+			expect((res.status as sinon.SinonStub).calledOnceWithExactly(HTTP.BAD_REQUEST)).to.be.true;
+			expect((res.render as sinon.SinonStub).calledOnceWithExactly('main/error.njk', {
+				status: HTTP.BAD_REQUEST,
+				error: 'Invalid authentication callback.',
+			})).to.be.true;
+			expect(acquireTokenByCodeStub.called).to.be.false;
+		});
+
+		it('stores SiLAS auth details and redirects on successful callback', async () => {
+			req.query = { code: 'auth-code', state: 'expected-state' };
+			const accessToken = buildAccessToken();
+			acquireTokenByCodeStub.resolves({
+				accessToken,
+				idToken: 'id-token',
+				expiresOn: new Date(123456789),
+				account: {
+					username: 'user@example.test',
+					name: 'Test User',
+					localAccountId: 'user-oid',
+				},
+			});
+
+			await handleSilasCallback(req as Request, res as Response);
+
+			expect(acquireTokenByCodeStub.calledOnce).to.be.true;
+			expect(regenerateStub.calledOnce).to.be.true;
+			expect(req.session.silasAuth).to.deep.equal({
+				accessToken,
+				idToken: 'id-token',
+				expiresAt: 123456789,
+				scopes: config.silas.scopes,
+			});
+			expect(req.session.user).to.deep.equal({
+				email: 'user@example.test',
+				name: 'Test User',
+				oid: 'user-oid',
+			});
+			expect(saveStub.calledOnce).to.be.true;
+			expect(res.redirect.calledOnceWithExactly('/cases/new')).to.be.true;
+		});
+
+		it('renders the mapping error message when the provider identity is not linked', async () => {
+			req.query = { code: 'auth-code', state: 'expected-state' };
+			acquireTokenByCodeStub.rejects(new SilasIdentityMappingError('not linked'));
+
+			await handleSilasCallback(req as Request, res as Response);
+
+			expect(res.status.calledOnceWithExactly(HTTP.BAD_REQUEST)).to.be.true;
+			expect(res.render.calledOnceWithExactly('main/error.njk', {
+				status: HTTP.BAD_REQUEST,
+				error: 'Your account is authenticated but not linked to a provider profile in MCC yet. Please contact the MCC support team.',
+			})).to.be.true;
+		});
+
+		it('renders a generic error when token exchange fails', async () => {
+			req.query = { code: 'auth-code', state: 'expected-state' };
+			acquireTokenByCodeStub.rejects(new Error('token exchange failed'));
+
+			await handleSilasCallback(req as Request, res as Response);
+
+			expect(res.status.calledOnceWithExactly(HTTP.BAD_REQUEST)).to.be.true;
+			expect(res.render.calledOnceWithExactly('main/error.njk', {
+				status: HTTP.BAD_REQUEST,
+				error: 'Unable to complete sign-in. Please try again.',
+			})).to.be.true;
+		});
+
+		it('rejects relay callbacks with an invalid relay target', async () => {
+			req.query = {
+				code: 'auth-code',
+				state: createRelayState(
+					'relay-nonce',
+					'https://evil.example.test',
+					config.session.secret,
+				),
+			};
+
+			await handleSilasCallback(req as Request, res as Response);
+
+			expect(res.status.calledOnceWithExactly(HTTP.BAD_REQUEST)).to.be.true;
+			expect(res.send.calledOnceWithExactly('Invalid relay target')).to.be.true;
+			expect(acquireTokenByCodeStub.called).to.be.false;
+		});
+
+		it('relays the callback to the target ephemeral environment', async () => {
+			req = {
+				...req,
+				hostname: 'main.example.test',
+				query: {
+					code: 'auth-code',
+					state: createRelayState(
+						'relay-nonce',
+						'https://branch-mcc-uat.cloud-platform.service.justice.gov.uk',
+						config.session.secret,
+					),
+				},
+			};
+
+			await handleSilasCallback(req as Request, res as Response);
+
+			expect(res.set.calledOnceWithExactly('Cache-Control', 'no-store')).to.be.true;
+			expect(res.redirect.calledOnceWithExactly(
+				`https://branch-mcc-uat.cloud-platform.service.justice.gov.uk/auth/callback?code=auth-code&state=${encodeURIComponent(req.query?.state as string)}`
+			)).to.be.true;
+			expect(acquireTokenByCodeStub.called).to.be.false;
+		});
+	});
+});

--- a/tests/unit/helpers/auth.spec.ts
+++ b/tests/unit/helpers/auth.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, afterEach } from 'mocha';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import type { Request, Response } from 'express';
+
+import config from '#config.js';
+import { HTTP } from '#src/services/api/base/constants.js';
+import { createRelayState } from '#utils/server/auth.relay.js';
+import { handleRelay } from '#src/scripts/helpers/auth.js';
+
+describe('handleRelay', () => {
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	function buildResponse(): Partial<Response> & {
+		redirect: sinon.SinonStub;
+		set: sinon.SinonStub;
+		status: sinon.SinonStub;
+		send: sinon.SinonStub;
+	} {
+		return {
+			redirect: sinon.stub(),
+			set: sinon.stub(),
+			status: sinon.stub().returnsThis(),
+			send: sinon.stub(),
+		};
+	}
+
+	it('returns false when the state is not a relay payload', () => {
+		const req = { hostname: 'app.example.test' } as Request;
+		const res = buildResponse();
+
+		const handled = handleRelay({ code: 'auth-code', state: 'plain-state' }, req, res as Response);
+
+		expect(handled).to.be.false;
+		expect(res.status.called).to.be.false;
+		expect(res.send.called).to.be.false;
+		expect(res.redirect.called).to.be.false;
+		expect(res.set.called).to.be.false;
+	});
+
+	it('rejects relay states with disallowed targets', () => {
+		const req = { hostname: 'app.example.test' } as Request;
+		const res = buildResponse();
+		const state = createRelayState(
+			'relay-nonce',
+			'https://evil.example.test',
+			config.session.secret,
+		);
+
+		const handled = handleRelay({ code: 'auth-code', state }, req, res as Response);
+
+		expect(handled).to.be.true;
+		expect(res.status.calledOnceWithExactly(HTTP.BAD_REQUEST)).to.be.true;
+		expect(res.send.calledOnceWithExactly('Invalid relay target')).to.be.true;
+		expect(res.redirect.called).to.be.false;
+		expect(res.set.called).to.be.false;
+	});
+
+	it('returns false when the relay target matches the current host', () => {
+		const targetHost = 'branch-mcc-uat.cloud-platform.service.justice.gov.uk';
+		const req = { hostname: targetHost } as Request;
+		const res = buildResponse();
+		const state = createRelayState(
+			'relay-nonce',
+			`https://${targetHost}`,
+			config.session.secret,
+		);
+
+		const handled = handleRelay({ code: 'auth-code', state }, req, res as Response);
+
+		expect(handled).to.be.false;
+		expect(res.status.called).to.be.false;
+		expect(res.send.called).to.be.false;
+		expect(res.redirect.called).to.be.false;
+		expect(res.set.called).to.be.false;
+	});
+
+	it('redirects to the relay target with the auth callback payload', () => {
+		const targetHost = 'branch-mcc-uat.cloud-platform.service.justice.gov.uk';
+		const req = { hostname: 'app.example.test' } as Request;
+		const res = buildResponse();
+		const state = createRelayState(
+			'relay-nonce',
+			`https://${targetHost}`,
+			config.session.secret,
+		);
+
+		const handled = handleRelay({ code: 'auth-code', state }, req, res as Response);
+
+		expect(handled).to.be.true;
+		expect(res.set.calledOnceWithExactly('Cache-Control', 'no-store')).to.be.true;
+		expect(res.redirect.calledOnceWithExactly(
+			`https://${targetHost}/auth/callback?code=auth-code&state=${encodeURIComponent(state)}`,
+		)).to.be.true;
+		expect(res.status.called).to.be.false;
+		expect(res.send.called).to.be.false;
+	});
+});

--- a/tests/unit/utils/server/auth.relay.spec.ts
+++ b/tests/unit/utils/server/auth.relay.spec.ts
@@ -1,0 +1,161 @@
+import { CryptoProvider } from "@azure/msal-node";
+import { expect } from "chai";
+
+import {
+  createRelayState,
+  isAllowedRelayTarget,
+  parseRelayState,
+  verifyRelayState,
+} from "#utils/server/auth.relay.js";
+
+const SECRET = "test-session-secret";
+const NONCE = "550e8400-e29b-41d4-a716-446655440000";
+const VALID_TARGET =
+  "https://el-257-feature-work-mcc-uat.cloud-platform.service.justice.gov.uk";
+
+describe("authRelay", () => {
+  describe("createRelayState / parseRelayState roundtrip", () => {
+    it("produces a base64-encoded string that parseRelayState can decode", () => {
+      const state = createRelayState(NONCE, VALID_TARGET, SECRET);
+      const parsed = parseRelayState(state);
+
+      expect(parsed).to.not.be.null;
+      expect(parsed!.nonce).to.equal(NONCE);
+      expect(parsed!.target).to.equal(VALID_TARGET);
+      expect(parsed!.signature).to.be.a("string").with.length.greaterThan(0);
+    });
+
+    it("is decodable by MSAL CryptoProvider.base64Decode without error", () => {
+      const state = createRelayState(NONCE, VALID_TARGET, SECRET);
+      const crypto = new CryptoProvider();
+      const decoded = crypto.base64Decode(state);
+      const parsed = JSON.parse(decoded) as Record<string, unknown>;
+
+      expect(parsed).to.have.property("nonce", NONCE);
+      expect(parsed).to.have.property("target", VALID_TARGET);
+      expect(parsed).to.have.property("signature");
+    });
+  });
+
+  describe("parseRelayState", () => {
+    it("returns null for a plain (non-relay) state", () => {
+      const plain = Buffer.from(JSON.stringify({ nonce: NONCE })).toString(
+        "base64",
+      );
+      expect(parseRelayState(plain)).to.be.null;
+    });
+
+    it("returns null for invalid base64", () => {
+      expect(parseRelayState("not-valid-base64!!!")).to.be.null;
+    });
+
+    it("returns null for non-JSON content", () => {
+      const state = Buffer.from("not json").toString("base64");
+      expect(parseRelayState(state)).to.be.null;
+    });
+
+    it("returns null when fields have wrong types", () => {
+      const state = Buffer.from(
+        JSON.stringify({ nonce: 123, signature: true, target: null }),
+      ).toString("base64");
+      expect(parseRelayState(state)).to.be.null;
+    });
+  });
+
+  describe("verifyRelaySignature", () => {
+    it("returns true for a valid signature", () => {
+      const state = createRelayState(NONCE, VALID_TARGET, SECRET);
+      const parsed = parseRelayState(state)!;
+      expect(verifyRelayState(parsed, SECRET)).to.be.true;
+    });
+
+    it("returns false when the signature has been tampered with", () => {
+      const state = createRelayState(NONCE, VALID_TARGET, SECRET);
+      const parsed = parseRelayState(state)!;
+      parsed.signature = "0".repeat(parsed.signature.length);
+      expect(verifyRelayState(parsed, SECRET)).to.be.false;
+    });
+
+    it("returns false when the target has been tampered with", () => {
+      const state = createRelayState(NONCE, VALID_TARGET, SECRET);
+      const parsed = parseRelayState(state)!;
+      parsed.target = "https://evil.com";
+      expect(verifyRelayState(parsed, SECRET)).to.be.false;
+    });
+
+    it("returns false when a different secret is used", () => {
+      const state = createRelayState(NONCE, VALID_TARGET, SECRET);
+      const parsed = parseRelayState(state)!;
+      expect(verifyRelayState(parsed, "wrong-secret")).to.be.false;
+    });
+
+    it("returns false when the signature length differs", () => {
+      const state = createRelayState(NONCE, VALID_TARGET, SECRET);
+      const parsed = parseRelayState(state)!;
+      parsed.signature = "short";
+      expect(verifyRelayState(parsed, SECRET)).to.be.false;
+    });
+  });
+
+  describe("isAllowedRelayTarget", () => {
+    it("accepts a valid ephemeral environment hostname", () => {
+      expect(isAllowedRelayTarget(VALID_TARGET)).to.be.true;
+    });
+
+    it("accepts single-segment branch prefixes", () => {
+      expect(
+        isAllowedRelayTarget(
+          "https://fix-42-mcc-uat.cloud-platform.service.justice.gov.uk",
+        ),
+      ).to.be.true;
+    });
+
+    it("rejects an arbitrary external domain", () => {
+      expect(isAllowedRelayTarget("https://evil.com")).to.be.false;
+    });
+
+    it("rejects an http URL (non-HTTPS)", () => {
+      expect(
+        isAllowedRelayTarget(
+          "http://el-257-deploy-mcc-uat.cloud-platform.service.justice.gov.uk",
+        ),
+      ).to.be.false;
+    });
+
+    it("rejects the UAT hostname itself (no branch prefix)", () => {
+      expect(
+        isAllowedRelayTarget(
+          "https://mcc-uat.cloud-platform.service.justice.gov.uk",
+        ),
+      ).to.be.false;
+    });
+
+    it("rejects a target with a path component that looks valid", () => {
+      expect(
+        isAllowedRelayTarget(
+          "https://evil.com/el-257-mcc-uat.cloud-platform.service.justice.gov.uk",
+        ),
+      ).to.be.false;
+    });
+
+    it("rejects a target using a query string to mimic the pattern", () => {
+      expect(
+        isAllowedRelayTarget(
+          "https://evil.com?x-mcc-uat.cloud-platform.service.justice.gov.uk",
+        ),
+      ).to.be.false;
+    });
+
+    it("rejects a hostname starting with a hyphen", () => {
+      expect(
+        isAllowedRelayTarget(
+          "https://-bad-mcc-uat.cloud-platform.service.justice.gov.uk",
+        ),
+      ).to.be.false;
+    });
+
+    it("rejects invalid URLs", () => {
+      expect(isAllowedRelayTarget("not-a-url")).to.be.false;
+    });
+  });
+});

--- a/utils/server/auth.relay.ts
+++ b/utils/server/auth.relay.ts
@@ -1,0 +1,124 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+
+const SERVICE = "mcc";
+// matches output from scripts/release-name.sh
+const ALLOWED_RELAY_HOSTNAME_PATTERN = new RegExp(
+  `^[a-z0-9]([a-z0-9-]*[a-z0-9])?-${SERVICE}-uat\\.cloud-platform\\.service\\.justice\\.gov\\.uk$`,
+);
+
+const relayStateSchema = z.object({
+  /** Cryptographically random nonce, used for CSRF protection and state matching. */
+  nonce: z.string(),
+  /** HMAC-SHA256 hex signature over `nonce` and `target`. */
+  signature: z.string(),
+  /** The HTTPS origin of the ephemeral environment that initiated the sign-in. */
+  target: z.string(),
+});
+
+export type RelayState = z.infer<typeof relayStateSchema>;
+
+/**
+ * Creates a base64-encoded relay state string for use as the OAuth `state` parameter.
+ *
+ * Encodes the nonce and target as JSON, signs the with an HMAC-SHA256
+ * signature derived from the secret, then base64 encodes the result.
+ * The state is stored in the session and verified on callback before any token exchange.
+ *
+ * @param {string} nonce - A cryptographically random UUID to prevent CSRF attacks.
+ * @param {string} target - The HTTPS origin of the ephemeral environment
+ * @param {string} secret - The session secret used to sign the.
+ * @returns {string} A base64-encoded JSON string containing `{ nonce, signature, target }`.
+ */
+export function createRelayState(
+  nonce: string,
+  target: string,
+  secret: string,
+): string {
+  const signature = sign({ nonce, target }, secret);
+  return Buffer.from(JSON.stringify({ nonce, signature, target })).toString(
+    "base64",
+  );
+}
+
+/**
+ * Returns `true` if the given URL is a permitted relay target.
+ *
+ * A valid target must use HTTPS and its hostname must match the ALLOWED_RELAY_HOSTNAME_PATTERN.
+ *
+ * @param {string} target - The full HTTPS origin URL to validate.
+ * @returns {boolean} `true` if the target is an allowed ephemeral environment origin, `false` otherwise.
+ */
+export function isAllowedRelayTarget(target: string): boolean {
+  try {
+    const url = new URL(target);
+    return (
+      url.protocol === "https:" &&
+      ALLOWED_RELAY_HOSTNAME_PATTERN.test(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Attempts to parse a base64-encoded OAuth state string as a relay state.
+ *
+ * Returns `null` for any plain (non-relay) state values, invalid base64, non-JSON content,
+ * or JSON that does not conform to the `RelayState` shape. This allows the caller
+ * to distinguish relay callbacks from normal callbacks without throwing.
+ *
+ * @param {string} stateString - The raw `state` query parameter value from the OAuth callback.
+ * @returns {RelayState | null} The decoded `RelayState` if the string is a valid relay state, or `null`.
+ */
+export function parseRelayState(stateString: string): null | RelayState {
+  try {
+    const decoded = JSON.parse(
+      Buffer.from(stateString, "base64").toString("utf8"),
+    ) as unknown;
+
+    const { data } = relayStateSchema.safeParse(decoded);
+    return data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verifies the HMAC-SHA256 signature of a relay state.
+ *
+ * Recomputes the expected signature from `state.nonce` and `state.target` using the
+ * provided secret, then compares it against `state.signature` using a timing-safe equality
+ * check to prevent timing attacks.
+ *
+ * @param {RelayState} state - The decoded relay state to verify.
+ * @param {string} secret - The session secret used when the state was originally signed.
+ * @returns {boolean} `true` if the signature is valid, `false` if it has been tampered with or the secret differs.
+ */
+export function verifyRelayState(state: RelayState, secret: string): boolean {
+  const signed = sign(state, secret);
+  const expected = Buffer.from(signed);
+  const actual = Buffer.from(state.signature);
+
+  if (expected.length !== actual.length) {
+    return false;
+  }
+  return timingSafeEqual(expected, actual);
+}
+
+/**
+ * Computes an HMAC-SHA256 hex digest over the relay state fields.
+ *
+ * The message format is `{nonce}:{target}`, providing domain separation between fields.
+ *
+ * @param {Omit<RelayState, "signature">} state - The relay state fields to sign.
+ * @param {string} state.nonce - Relay state nonce
+ * @param {string} state.target - Relay state target
+ * @param {string} secret - The HMAC signing key.
+ * @returns {string} A hex-encoded HMAC-SHA256 digest.
+ */
+function sign(state: Omit<RelayState, "signature">, secret: string): string {
+  return createHmac("sha256", secret)
+    .update(`${state.nonce}:${state.target}`)
+    .digest("hex");
+}

--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -24,3 +24,10 @@ export {
     setupSocketIO,
     type RedisClientType
 };
+
+export {
+    createRelayState,
+    isAllowedRelayTarget,
+    parseRelayState,
+    verifyRelayState,
+} from './auth.relay.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4943,6 +4943,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.22.4"
     typescript: "npm:^6.0.3"
+    zod: "npm:^4.4.3"
   languageName: unknown
   linkType: soft
 
@@ -7824,5 +7825,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zod@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
   languageName: node
   linkType: hard


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-3235

## What changed and Why?

OAuth relay so ephemeral environments can authenticate via UAT as a broker.

Registering each branch UAT environment's callback URL with Microsoft Entra is impractical. Instead, all environments register only the UAT callback URL. When a user signs in from an ephemeral environment, the sign-in flow targets UAT's callback, which validates and forwards the code to the correct ephemeral environment.


## Guidance to review (optional)

- Adds util functions `src/utils/server/auth.relay.ts`. Relay state is base64-encoded JSON with HMAC-SHA256 signature using the shared session secret.
- Adds util function `handleRelay` to `helpers/auth.ts`, which is meant to be used as the entry point for controller. This has been separated into its own util function more closely related to controller/server logic.
- Updates login controller so that it detects relay state on the callback, validates the signature and allowlist, then redirects to the branch UAT target. Processes as normal if the target matches the current host.
- Removes the need to change `ENTRA_REDIRECT_URI`.

Caveats:
- The relay relies on SESSION_SECRET being the same across UAT and all ephemeral environments. This is already the case as all deployments in the UAT namespace share the same secrets.
- For testing this branch, these codes changes need to be deployed to main UAT, as that is acting as a broker/intermediary in this flow. If any reviewer wants to test this, please add a comment and this can be deployed directly to main UAT as a one-off action.

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.