### PR TITLE
EL-3281: Add conditional logic and tests to financial eligibility

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -249,6 +249,14 @@
         "warning": "Client does not qualify for legal aid",
         "information": "Review the financial eligibility information and check if you can update any marked 'not provided'",
         "informationTitle": "Means test incomplete"
+      },
+      "message": {
+        "noMeansTestTitle": "No means test required",
+        "noMeansTestBody": "The means of the foster parents or approved prospective adoptive parents are exempt from the determination of financial eligibility. See regulation 5 of the Civil Legal Aid (Financial Resources and Payment for Services) Regulations 2013, as amended by the Criminal and Civil Legal Aid (Amendment) Regulations 2023 for more information.",
+        "fullTestNotRequiredTitle": "Full means test not required",
+        "fullTestNotRequiredBody": "Client is under 18, they don't have assets worth £2,500 or more, and they don't get regular income. This makes them eligible without a full means test.",
+        "incomeAssessmentNotRequiredTitle": "Income assessment not required",
+        "incomeAssessmentNotRequiredBody": "Client receives a passporting benefit so they will not need an income assessment."
       }
     }
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -10,6 +10,7 @@
     "signOut": "Sign out",
     "yes": "Yes",
     "no": "No",
+    "none": "None",
     "continue": "Continue",
     "error": "Error",
     "warning": "Warning",

--- a/src/services/api/resources/clientDetailsApiService.ts
+++ b/src/services/api/resources/clientDetailsApiService.ts
@@ -255,7 +255,7 @@ export async function getFinancialEligibility(axiosMiddleware: AxiosInstanceWrap
     
     const configuredAxios = configureAxiosInstance(axiosMiddleware);
     const response = await configuredAxios.get(`${API_PREFIX}/case/${caseReference}/eligibility_check/`);
-    console.log("financial data: ", response.data)
+    
     devLog(`API: Get financial eligibility response: ${JSON.stringify(response.data, null, JSON_INDENT)}`);
     return {
       data: transformFinancialEligibilityItem(response.data),

--- a/src/services/api/transforms/transformFinancialEligibility.ts
+++ b/src/services/api/transforms/transformFinancialEligibility.ts
@@ -48,6 +48,7 @@ export function transformFinancialEligibilityItem(item: unknown): FinancialEligi
   const hasPassportedProceedingsLetter = Boolean(item.has_passported_proceedings_letter);
   const passportedBenefits = Boolean(item.on_passported_benefits);
   const under18passportedBenefits = Boolean(item.under_18_passported);
+  const category = String(item.category);
 
   return {
     hasPartner,
@@ -66,7 +67,8 @@ export function transformFinancialEligibilityItem(item: unknown): FinancialEligi
     state,
     hasPassportedProceedingsLetter,
     passportedBenefits,
-    under18passportedBenefits
+    under18passportedBenefits,
+    category
   };
 }
 

--- a/src/services/api/transforms/transformFinancialEligibility.ts
+++ b/src/services/api/transforms/transformFinancialEligibility.ts
@@ -45,6 +45,9 @@ export function transformFinancialEligibilityItem(item: unknown): FinancialEligi
   const under18RegularPayment = Boolean(item.under_18_receive_regular_payment);
   const under18HasValuables = Boolean(item.under_18_has_valuables);
   const state = String(item.state);
+  const hasPassportedProceedingsLetter = Boolean(item.has_passported_proceedings_letter);
+  const passportedBenefits = Boolean(item.on_passported_benefits);
+  const under18passportedBenefits = Boolean(item.under_18_passported);
 
   return {
     hasPartner,
@@ -60,7 +63,10 @@ export function transformFinancialEligibilityItem(item: unknown): FinancialEligi
     under18RegularPayment,
     under18HasValuables,
     disputedSavings,
-    state
+    state,
+    hasPassportedProceedingsLetter,
+    passportedBenefits,
+    under18passportedBenefits
   };
 }
 
@@ -69,9 +75,9 @@ export function transformFinancialEligibilityItem(item: unknown): FinancialEligi
  * @param {unknown} savings savings data to be formatted
  * @returns {SavingsData} formatted savings data
  */
-function formatSavingsData(savings: unknown): SavingsData {
+function formatSavingsData(savings: unknown): SavingsData | null {
   if (!isRecord(savings)) {
-    return {} as SavingsData;
+    return null;
   }
   return {
     bankBalance: convertPenceToPounds(Number(savings.bank_balance ?? 0)),

--- a/tests/playwright/fixtures/mock-data.json
+++ b/tests/playwright/fixtures/mock-data.json
@@ -1266,6 +1266,19 @@
       "callbackPreference": "No",
       "languageSupportNeeds": "English",
       "notes": "Here are some notes from the operator!"
+    },
+    "financialEligibility": {
+      "under_18_passported": false,
+      "is_you_under_18": true,
+      "under_18_receive_regular_payment": true,
+      "under_18_has_valuables": false,
+      "specific_benefits": {
+        "pension_credit": false,
+        "job_seekers_allowance": false,
+        "employment_support": false,
+        "universal_credit": false,
+        "income_support": false
+      }
     }
   },
   {

--- a/tests/playwright/fixtures/mock-data.json
+++ b/tests/playwright/fixtures/mock-data.json
@@ -62,7 +62,7 @@
     "refCode": "",
     "dateReceived": "2025-01-14T19:00:00-05:00",
     "caseStatus": "New",
-    "category": "Housing, eviction and homelessness",
+    "category": "Family, marriage, separation and children",
     "isUrgent": true,
     "dateOfBirth": "1993-11-15T00:00:00-05:00",
     "vulnerableUser": false,
@@ -102,7 +102,34 @@
       "notes": "",
       "no_adaptations_required": false
     },
-    "lastModified": "2025-07-06T19:00:00-05:00"
+    "lastModified": "2025-07-06T19:00:00-05:00",
+    "financialEligibility": {
+       "category": "family",
+       "savings": {
+          "bank_balance": 20000,
+          "investment_balance": 10000,
+          "asset_balance": 50000,
+          "credit_balance": 20000,
+          "total": 100000
+        },
+      "disputed_savings": {
+          "bank_balance": 20000,
+          "investment_balance": 10000,
+          "asset_balance": 50000,
+          "credit_balance": 20000,
+          "total": 100000
+      },
+       "property_set": [
+        {
+          "value": 13000000,
+          "mortgage_left": 5000000,
+          "share": 100,
+          "id": 1361,
+          "disputed": true,
+          "main": false
+        }
+      ]
+    }
   },
   {
     "fullName": "Jack Youngs",
@@ -337,6 +364,7 @@
     "financialEligibility": {
       "disputed_savings": null,
        "state": "unknown",
+       "category": "debt",
        "property_set": [
         {
           "value": 13000000,
@@ -364,7 +392,7 @@
     "refCode": "",
     "dateReceived": "2025-07-06T19:00:00-05:00",
     "caseStatus": "New",
-    "category": "Housing, eviction and homelessness",
+    "category": "Debt, money problems and bankruptcy",
     "isUrgent": true,
     "dateOfBirth": "1981-08-18T00:00:00-05:00",
     "vulnerableUser": true,
@@ -377,6 +405,7 @@
     "laaReference": "8196672",
     "lastModified": "2025-07-06T19:00:00-05:00",
     "financialEligibility": {
+       "category": "debt",
        "savings": {
           "bank_balance": 20000,
           "investment_balance": 10000,
@@ -722,7 +751,7 @@
       "your_problem_notes": "",
       "reference": "PC-9173-4826",
       "notes": "",
-      "category": "Housing, eviction and homelessness",
+      "category": "family",
       "property_set": [
         {
           "value": 15000000,
@@ -1143,6 +1172,123 @@
       "callbackPreference": "No",
       "languageSupportNeeds": "English",
       "notes": "Client has a calm manner and cooperates well. Missing left arm noted but no mobility concerns."
+    },
+    "financialEligibility": {
+      "your_problem_notes": "",
+      "reference": "PC-1922-1879",
+      "state": "yes",
+      "notes": "",
+      "category": "family",
+      "disputed_savings": null,
+      "property_set": [
+        {
+          "value": 13000000,
+          "mortgage_left": 5000000,
+          "share": 100,
+          "id": 1361,
+          "disputed": false,
+          "main": false
+        },
+        {
+          "value": 12000000,
+          "mortgage_left": 6000000,
+          "share": 100,
+          "id": 1360,
+          "disputed": false,
+          "main": true
+        }
+      ],
+      "you": {
+        "income": {
+          "earnings": {
+            "per_interval_value": 15000,
+            "interval_period": "per_month"
+          },
+          "self_employment_drawings": {
+            "per_interval_value": 10000,
+            "interval_period": "per_week"
+          },
+          "benefits": {
+            "per_interval_value": 5000,
+            "interval_period": "per_year"
+          },
+          "tax_credits": {
+            "per_interval_value": 20000,
+            "interval_period": "per_month"
+          },
+          "child_benefits": {
+            "per_interval_value": 10000,
+            "interval_period": "per_month"
+          },
+          "maintenance_received": {
+            "per_interval_value": 0,
+            "interval_period": "per_month"
+          },
+          "pension": {
+            "per_interval_value": 0,
+            "interval_period": "per_month"
+          },
+          "other_income": {
+            "per_interval_value": 0,
+            "interval_period": "per_month"
+          },
+          "self_employed": false,
+          "total": 88749
+        },
+        "savings": {
+          "bank_balance": 20000,
+          "investment_balance": 10000,
+          "asset_balance": 50000,
+          "credit_balance": 20000,
+          "total": 100000
+        },
+        "deductions": {
+          "income_tax": {
+            "per_interval_value": 10000,
+            "interval_period": "per_4week"
+          },
+          "national_insurance": {
+            "per_interval_value": 20000,
+            "interval_period": "per_2week"
+          },
+          "maintenance": {
+            "per_interval_value": 5000,
+            "interval_period": "per_month"
+          },
+          "childcare": {
+            "per_interval_value": 2000,
+            "interval_period": "per_month"
+          },
+          "mortgage": {
+            "per_interval_value": 20000,
+            "interval_period": "per_month"
+          },
+          "rent": {
+            "per_interval_value": 0,
+            "interval_period": "per_month"
+          },
+          "criminal_legalaid_contributions": 1000,
+          "total": 38000
+        }
+      },
+      "partner": {
+        "income": {},
+        "savings": {},
+        "deductions": {}
+      },
+      "dependants_young": 0,
+      "dependants_old": 0,
+      "is_you_or_your_partner_over_60": false,
+      "has_partner": false,
+      "is_you_under_18": false,
+      "specific_benefits": {
+        "pension_credit": false,
+        "job_seekers_allowance": true,
+        "employment_support": false,
+        "universal_credit": true,
+        "income_support": false
+      },
+      "disregards": null
     }
   },
   {
@@ -1223,6 +1369,19 @@
       "callbackPreference": "No",
       "languageSupportNeeds": "English",
       "notes": "Client becomes flustered when speaking; may require calm communication approach."
+    },
+     "financialEligibility": {
+      "under_18_passported": false,
+      "is_you_under_18": true,
+      "under_18_receive_regular_payment": false,
+      "under_18_has_valuables": true,
+      "specific_benefits": {
+        "pension_credit": false,
+        "job_seekers_allowance": false,
+        "employment_support": false,
+        "universal_credit": false,
+        "income_support": false
+      }
     }
   },
   {

--- a/tests/playwright/fixtures/mock-data.json
+++ b/tests/playwright/fixtures/mock-data.json
@@ -335,7 +335,26 @@
     },
     "lastModified": "2025-07-06T19:00:00-05:00",
     "financialEligibility": {
-      "state": "unknown"
+      "disputed_savings": null,
+       "state": "unknown",
+       "property_set": [
+        {
+          "value": 13000000,
+          "mortgage_left": 5000000,
+          "share": 100,
+          "id": 1361,
+          "disputed": true,
+          "main": false
+        },
+        {
+          "value": 12000000,
+          "mortgage_left": 6000000,
+          "share": 100,
+          "id": 1360,
+          "disputed": false,
+          "main": true
+        }
+      ]
     }
   },
   {
@@ -356,7 +375,33 @@
     "address": "871 Holyhead Lane, Bangor",
     "postcode": "LL53 2AD",
     "laaReference": "8196672",
-    "lastModified": "2025-07-06T19:00:00-05:00"
+    "lastModified": "2025-07-06T19:00:00-05:00",
+    "financialEligibility": {
+       "savings": {
+          "bank_balance": 20000,
+          "investment_balance": 10000,
+          "asset_balance": 50000,
+          "credit_balance": 20000,
+          "total": 100000
+        },
+      "disputed_savings": {
+          "bank_balance": 20000,
+          "investment_balance": 10000,
+          "asset_balance": 50000,
+          "credit_balance": 20000,
+          "total": 100000
+      },
+       "property_set": [
+        {
+          "value": 13000000,
+          "mortgage_left": 5000000,
+          "share": 100,
+          "id": 1361,
+          "disputed": true,
+          "main": false
+        }
+      ]
+    }
   },
   {
     "fullName": "Barbra white",
@@ -539,7 +584,10 @@
         "passphrase": "LetMeIn"
       }
     },
-    "lastModified": "2025-01-05T19:00:00-05:00"
+    "lastModified": "2025-01-05T19:00:00-05:00",
+    "financialEligibility": {
+      "has_passported_proceedings_letter": true
+    }
   },
   {
     "fullName": "Zechariah Twelve",
@@ -626,7 +674,13 @@
       "notes": "",
       "no_adaptations_required": false
     },
-    "lastModified": "2025-01-05T19:00:00-05:00"
+    "lastModified": "2025-01-05T19:00:00-05:00",
+     "financialEligibility": {
+      "under_18_passported": true,
+      "is_you_under_18": true,
+      "under_18_receive_regular_payment": false,
+      "under_18_has_valuables": false
+    }
   },
   {
     "fullName": "Ian Phillips",
@@ -662,6 +716,123 @@
         "selected": [
           "No, client is a child or patient"
         ]
+      }
+    },
+    "financialEligibility": {
+      "your_problem_notes": "",
+      "reference": "PC-9173-4826",
+      "notes": "",
+      "category": "Housing, eviction and homelessness",
+      "property_set": [
+        {
+          "value": 15000000,
+          "mortgage_left": 6000000,
+          "share": 100,
+          "id": 1362,
+          "disputed": false,
+          "main": true
+        }
+      ],
+      "you": {
+        "income": {
+          "earnings": {
+            "per_interval_value": 12000,
+            "interval_period": "per_month"
+          },
+          "self_employment_drawings": {
+            "per_interval_value": 20000,
+            "interval_period": "per_week"
+          },
+          "benefits": {
+            "per_interval_value": 50000,
+            "interval_period": "per_year"
+          },
+          "tax_credits": {
+            "per_interval_value": 10000,
+            "interval_period": "per_month"
+          },
+          "child_benefits": {
+            "per_interval_value": 20000,
+            "interval_period": "per_month"
+          },
+          "maintenance_received": {
+            "per_interval_value": 10000,
+            "interval_period": "per_month"
+          },
+          "pension": {
+            "per_interval_value": 10000,
+            "interval_period": "per_month"
+          },
+          "other_income": {
+            "per_interval_value": 0,
+            "interval_period": "per_month"
+          },
+          "self_employed": false,
+          "total": 88749
+        },
+        "savings": {
+          "bank_balance": 10000,
+          "investment_balance": 30000,
+          "asset_balance": 50000,
+          "credit_balance": 10000,
+          "total": 90000
+        },
+        "deductions": {
+          "income_tax": {
+            "per_interval_value": 0,
+            "interval_period": "per_4week"
+          },
+          "national_insurance": {
+            "per_interval_value": 0,
+            "interval_period": "per_2week"
+          },
+          "maintenance": {
+            "per_interval_value": 5000,
+            "interval_period": "per_month"
+          },
+          "childcare": {
+            "per_interval_value": 5000,
+            "interval_period": "per_month"
+          },
+          "mortgage": {
+            "per_interval_value": 35000,
+            "interval_period": "per_month"
+          },
+          "rent": {
+            "per_interval_value": 25000,
+            "interval_period": "per_month"
+          },
+          "criminal_legalaid_contributions": 2000,
+          "total": 38000
+        }
+      },
+      "partner": {
+        "income": {},
+        "savings": {},
+        "deductions": {}
+      },
+      "disputed_savings": {
+          "bank_balance": 10000,
+          "investment_balance": 30000,
+          "asset_balance": 50000,
+          "credit_balance": 10000,
+          "total": 90000
+        },
+      "dependants_young": 1,
+      "dependants_old": 2,
+      "is_you_or_your_partner_over_60": false,
+      "has_partner": true,
+      "on_passported_benefits": true,
+      "is_you_under_18": false,
+      "specific_benefits": {
+        "pension_credit": false,
+        "job_seekers_allowance": false,
+        "employment_support": false,
+        "universal_credit": false,
+        "income_support": false
+      },
+      "disregards": {
+        "cost_living": true
       }
     }
   },

--- a/tests/playwright/tests/financial-eligibility.spec.ts
+++ b/tests/playwright/tests/financial-eligibility.spec.ts
@@ -548,9 +548,9 @@ test.describe('Conditional logic views', () => {
 
   test('when has_passported_proceedings_letter = true no financial information is shown', async ({ page }) => {
     const clientDetails = ClientDetailsPage.forCase(page, 'PC-4575-7150');
-    // Navingate to client details page
+    // Navigate to client details page
     await clientDetails.navigate();
-    // Click the financial eligiblity tab
+    // Click the financial eligibility tab
     await page.getByRole('link', { name: 'Financial eligibility' }).click();
     // Assert the URL has change to financial eligibility tab
     await expect(page).toHaveURL(/financial-eligibility/);

--- a/tests/playwright/tests/financial-eligibility.spec.ts
+++ b/tests/playwright/tests/financial-eligibility.spec.ts
@@ -630,6 +630,38 @@ test.describe('Conditional logic views', () => {
     });
   });
 
+   test('when client is under 18 and doesnt get regular payments but has valuables is true has partner and over 60 questions are shown', async ({ page }) => {
+    const clientDetails = ClientDetailsPage.forCase(page, 'PC-2211-4466');
+
+    await clientDetails.navigate();
+
+    await page.getByRole('link', { name: 'Financial eligibility' }).click();
+
+    await expect(page).toHaveURL(/financial-eligibility/);
+
+    // Assert the 'About you' header is visible
+    await expect(page.getByText('About you')).toBeVisible();
+    // Assert the 'Benefits' header is visible
+    await expect(page.locator('caption').filter({ hasText: 'Benefits' })).toBeVisible();
+
+     // Assert the financial eligibility tabs are visible
+    await expect(page.getByRole('tab', { name: 'Details' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Finances' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Income' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Expenses' })).toBeVisible();
+
+    const aboutYouTable = page.getByRole('table').first();
+
+     // Assert the correct data is displayed in the about you section
+    await expectCaptionTableRows(page, 'About you', {
+      'Are you aged 17 or under?': 'Yes',
+      'Do you receive any money on a regular basis?': 'No',
+      'Do you have any savings, items of value or investments totalling £2500 or more?': 'Yes',
+      'Do you have a partner?': 'No',
+      'Are you aged 60 or over?': 'No'
+    });
+  });
+
   test('when on_passported_benefits = true only details and finances tabs are shown', async ({ page }) => {
     const clientDetails = ClientDetailsPage.forCase(page, 'PC-9173-4826');
 
@@ -687,7 +719,7 @@ test.describe('Conditional logic views', () => {
     await expect(page.getByText("Your partner's expenses")).toHaveCount(0);
   });
 
-  test('when disputed_savings is null disputed savings information is not shown', async ({ page }) => {
+  test('when category is debt and disputed_savings is null disputed savings information is not shown', async ({ page }) => {
     const clientDetails = ClientDetailsPage.forCase(page, 'PC-1977-1241');
 
     await clientDetails.navigate();
@@ -697,15 +729,40 @@ test.describe('Conditional logic views', () => {
 
     await page.getByRole('tab', { name: 'Finances' }).click();
 
-    // Disputed savings section should not be rendered
-    await expect(page.getByRole('heading', { name: 'Your disputed savings' })).toHaveCount(0);
+    // Disputed savings section should be rendered
+    await expect(page.getByRole('heading', { name: 'Your disputed savings' })).toHaveCount(1);
 
-    // Disputed property row should not be rendered
-    await expect(page.getByText('Is the property disputed?')).toHaveCount(0);
+    // Disputed savings should have none
+    await expect(page.getByText('None')).toHaveCount(1);
+
+    // Disputed property row should be rendered and display value (mock data has 2 properties)
+    await expect(page.getByText('Is the property disputed?')).toHaveCount(2);
   });
 
-   test('when disputed_savings is not null disputed savings information is shown', async ({ page }) => {
+   test('when category is debt and disputed_savings is not null disputed savings information is shown', async ({ page }) => {
     const clientDetails = ClientDetailsPage.forCase(page, 'PC-1357-1212');
+
+    await clientDetails.navigate();
+
+    await page.getByRole('link', { name: 'Financial eligibility' }).click();
+    await expect(page).toHaveURL(/financial-eligibility/);
+
+    await page.getByRole('tab', { name: 'Finances' }).click();
+
+    // Disputed savings section should be rendered
+    await expect(page.getByRole('heading', { name: 'Your disputed savings' })).toHaveCount(1);
+
+    // Assert the correct data is displayed in the your disputed savings table.
+    await expectPropertyTableRows(page, 'Your disputed savings', {
+      'How much was in your bank account/building society before your last payment went in?': '£200',
+      'Do you have any investments, shares or ISAs?': '£100',
+      'Do you have any valuable items worth over £500 each?': '£500',
+      'Do you have any money owed to you?': '£200'
+    });
+  });
+
+   test('when category is family and disputed_savings is not null disputed savings information is shown', async ({ page }) => {
+    const clientDetails = ClientDetailsPage.forCase(page, 'PC-9173-4826');
 
     await clientDetails.navigate();
 
@@ -717,7 +774,32 @@ test.describe('Conditional logic views', () => {
     // Disputed savings section should not be rendered
     await expect(page.getByRole('heading', { name: 'Your disputed savings' })).toHaveCount(1);
 
-    // Disputed property row should not be rendered
-    await expect(page.getByText('Is the property disputed?')).toHaveCount(1);
+    // Assert the correct data is displayed in the your disputed savings table.
+    await expectPropertyTableRows(page, 'Your disputed savings', {
+      'How much was in your bank account/building society before your last payment went in?': '£100',
+      'Do you have any investments, shares or ISAs?': '£300',
+      'Do you have any valuable items worth over £500 each?': '£500',
+      'Do you have any money owed to you?': '£100'
+    });
+  });
+
+    test('when category is family and disputed_savings is null disputed savings information is not shown', async ({ page }) => {
+    const clientDetails = ClientDetailsPage.forCase(page, 'PC-1122-3344');
+
+    await clientDetails.navigate();
+
+    await page.getByRole('link', { name: 'Financial eligibility' }).click();
+    await expect(page).toHaveURL(/financial-eligibility/);
+
+    await page.getByRole('tab', { name: 'Finances' }).click();
+
+    // Disputed savings section should not be rendered
+    await expect(page.getByRole('heading', { name: 'Your disputed savings' })).toHaveCount(1);
+
+    // Disputed savings should have none
+    await expect(page.getByText('None')).toHaveCount(1);
+
+    // Disputed property row should be rendered
+    await expect(page.getByText('Is the property disputed?')).toHaveCount(2);
   });
 });

--- a/tests/playwright/tests/financial-eligibility.spec.ts
+++ b/tests/playwright/tests/financial-eligibility.spec.ts
@@ -583,7 +583,6 @@ test.describe('Conditional logic views', () => {
 
     // Only Details tab displayed
     await expect(page.getByRole('tab', { name: 'Details' })).toBeVisible();
-
     await expect(page.getByRole('tab', { name: 'Finances' })).toHaveCount(0);
     await expect(page.getByRole('tab', { name: 'Income' })).toHaveCount(0);
     await expect(page.getByRole('tab', { name: 'Expenses' })).toHaveCount(0);
@@ -598,6 +597,37 @@ test.describe('Conditional logic views', () => {
 
     await expect(aboutYouTable).toContainText('Do you have any savings, items of value or investments totalling £2500 or more?');
     await expect(aboutYouTable).toContainText('No');
+  });
+
+  test('when client is under 18 and gets regular payments has partner and over 60 questions are shown', async ({ page }) => {
+    const clientDetails = ClientDetailsPage.forCase(page, 'PC-1854-6521');
+
+    await clientDetails.navigate();
+
+    await page.getByRole('link', { name: 'Financial eligibility' }).click();
+
+    await expect(page).toHaveURL(/financial-eligibility/);
+
+    // Assert the 'About you' header is visible
+    await expect(page.getByText('About you')).toBeVisible();
+    // Assert the 'Benefits' header is visible
+    await expect(page.locator('caption').filter({ hasText: 'Benefits' })).toBeVisible();
+
+     // Assert the financial eligibility tabs are visible
+    await expect(page.getByRole('tab', { name: 'Details' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Finances' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Income' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Expenses' })).toBeVisible();
+
+    const aboutYouTable = page.getByRole('table').first();
+
+     // Assert the correct data is displayed in the about you section
+    await expectCaptionTableRows(page, 'About you', {
+      'Are you aged 17 or under?': 'Yes',
+      'Do you receive any money on a regular basis?': 'Yes',
+      'Do you have a partner?': 'No',
+      'Are you aged 60 or over?': 'No'
+    });
   });
 
   test('when on_passported_benefits = true only details and finances tabs are shown', async ({ page }) => {

--- a/tests/playwright/tests/financial-eligibility.spec.ts
+++ b/tests/playwright/tests/financial-eligibility.spec.ts
@@ -541,3 +541,153 @@ test.describe('Financial Eligibility result', () => {
     await expect(alert).toContainText("Review the financial eligibility information and check if you can update any marked 'not provided'");
   });
 });
+test.describe('Conditional logic views', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupAuth(page);
+  });
+
+  test('when has_passported_proceedings_letter = true no financial information is shown', async ({ page }) => {
+    const clientDetails = ClientDetailsPage.forCase(page, 'PC-4575-7150');
+    // Navingate to client details page
+    await clientDetails.navigate();
+    // Click the financial eligiblity tab
+    await page.getByRole('link', { name: 'Financial eligibility' }).click();
+    // Assert the URL has change to financial eligibility tab
+    await expect(page).toHaveURL(/financial-eligibility/);
+
+    // Tabs should not be displayed
+    await expect(page.getByRole('tab', { name: 'Details' })).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Finances' })).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Income' })).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Expenses' })).toHaveCount(0);
+
+    // Message should be displayed
+    await expect(page.getByText('No means test required')).toBeVisible();
+
+    await expect(page.getByText('The means of the foster parents or approved prospective adoptive parents are exempt from the determination of financial eligibility.')).toBeVisible();
+  });
+
+  test('when under_18_passported = true only the details tab is shown', async ({ page }) => {
+    const clientDetails = ClientDetailsPage.forCase(page, 'PC-6667-9089');
+
+    await clientDetails.navigate();
+
+    await page.getByRole('link', { name: 'Financial eligibility' }).click();
+
+    await expect(page).toHaveURL(/financial-eligibility/);
+
+    // Message displayed
+    await expect(page.getByText('Full means test not required')).toBeVisible();
+
+    await expect(page.getByText("Client is under 18, they don't have assets worth £2,500 or more, and they don't get regular income.")).toBeVisible();
+
+    // Only Details tab displayed
+    await expect(page.getByRole('tab', { name: 'Details' })).toBeVisible();
+
+    await expect(page.getByRole('tab', { name: 'Finances' })).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Income' })).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Expenses' })).toHaveCount(0);
+
+    const aboutYouTable = page.getByRole('table').first();
+
+    await expect(aboutYouTable).toContainText('Are you aged 17 or under?');
+    await expect(aboutYouTable).toContainText('Yes');
+
+    await expect(aboutYouTable).toContainText('Do you receive any money on a regular basis?');
+    await expect(aboutYouTable).toContainText('No');
+
+    await expect(aboutYouTable).toContainText('Do you have any savings, items of value or investments totalling £2500 or more?');
+    await expect(aboutYouTable).toContainText('No');
+  });
+
+  test('when on_passported_benefits = true only details and finances tabs are shown', async ({ page }) => {
+    const clientDetails = ClientDetailsPage.forCase(page, 'PC-9173-4826');
+
+    await clientDetails.navigate();
+
+    await page.getByRole('link', { name: 'Financial eligibility' }).click();
+
+    await expect(page).toHaveURL(/financial-eligibility/);
+
+    // Message displayed
+    await expect(page.getByText('Income assessment not required')).toBeVisible();
+    await expect(page.getByText('Client receives a passporting benefit so they will not need an income assessment.')).toBeVisible();
+
+    // Correct tabs displayed
+    await expect(page.getByRole('tab', { name: 'Details' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Finances' })).toBeVisible();
+
+    // Tabs not displayed
+    await expect(page.getByRole('tab', { name: 'Income' })).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Expenses' })).toHaveCount(0);
+
+    // Details tab content
+    const aboutYouTable = page.getByRole('table').first();
+
+    await expect(aboutYouTable).toContainText('Are you aged 17 or under?');
+    await expect(aboutYouTable).toContainText('Do you have a partner?');
+    await expect(aboutYouTable).toContainText('Are you aged 60 or over?');
+
+    // Benefits table
+    await expect(page.getByText('Universal Credit')).toBeVisible();
+    await expect(page.getByText('Income Support')).toBeVisible();
+
+    // Open finances tab
+    await page.getByRole('tab', { name: 'Finances' }).click();
+    await expect(page.getByText('Your savings')).toBeVisible();
+    await expect(page.getByText('Cost of living payment')).toBeVisible();
+  });
+
+  test('when hasPartner is false partner savings, income and expenses are not shown', async ({ page }) => {
+    const clientDetails = ClientDetailsPage.forCase(page, 'PC-1922-1879');
+
+    await clientDetails.navigate();
+    await page.getByRole('link', { name: 'Financial eligibility' }).click();
+
+    // Finances tab
+    await page.getByRole('tab', { name: 'Finances' }).click();
+    await expect(page.getByText('Your partners savings')).toHaveCount(0);
+
+    // Income tab
+    await page.getByRole('tab', { name: 'Income' }).click();
+    await expect(page.getByText("Partner's income")).toHaveCount(0);
+
+    // Expenses tab
+    await page.getByRole('tab', { name: 'Expenses' }).click();
+    await expect(page.getByText("Your partner's expenses")).toHaveCount(0);
+  });
+
+  test('when disputed_savings is null disputed savings information is not shown', async ({ page }) => {
+    const clientDetails = ClientDetailsPage.forCase(page, 'PC-1977-1241');
+
+    await clientDetails.navigate();
+
+    await page.getByRole('link', { name: 'Financial eligibility' }).click();
+    await expect(page).toHaveURL(/financial-eligibility/);
+
+    await page.getByRole('tab', { name: 'Finances' }).click();
+
+    // Disputed savings section should not be rendered
+    await expect(page.getByRole('heading', { name: 'Your disputed savings' })).toHaveCount(0);
+
+    // Disputed property row should not be rendered
+    await expect(page.getByText('Is the property disputed?')).toHaveCount(0);
+  });
+
+   test('when disputed_savings is not null disputed savings information is shown', async ({ page }) => {
+    const clientDetails = ClientDetailsPage.forCase(page, 'PC-1357-1212');
+
+    await clientDetails.navigate();
+
+    await page.getByRole('link', { name: 'Financial eligibility' }).click();
+    await expect(page).toHaveURL(/financial-eligibility/);
+
+    await page.getByRole('tab', { name: 'Finances' }).click();
+
+    // Disputed savings section should not be rendered
+    await expect(page.getByRole('heading', { name: 'Your disputed savings' })).toHaveCount(1);
+
+    // Disputed property row should not be rendered
+    await expect(page.getByText('Is the property disputed?')).toHaveCount(1);
+  });
+});

--- a/tests/unit/helpers/transformFinancialEligibility.spec.ts
+++ b/tests/unit/helpers/transformFinancialEligibility.spec.ts
@@ -254,7 +254,7 @@ describe('transformFinancialEligilibilityItem', () => {
     const result = transformFinancialEligibilityItem({});
 
     expect(result.clientData.income).to.deep.equal({});
-    expect(result.clientData.savings).to.deep.equal({});
+    expect(result.clientData.savings).to.deep.equal(null);
     expect(result.clientData.deductions).to.deep.equal({});
   });
 
@@ -265,7 +265,7 @@ describe('transformFinancialEligilibilityItem', () => {
     });
 
     expect(result.partnerData.partnerIncome).to.deep.equal({});
-    expect(result.partnerData.partnerSavings).to.deep.equal({});
+    expect(result.partnerData.partnerSavings).to.deep.equal(null);
     expect(result.partnerData.partnerDeductions).to.deep.equal({});
   });
 

--- a/types/api-types.ts
+++ b/types/api-types.ts
@@ -366,17 +366,6 @@ export interface SavingsData {
 }
 
 /**
- * Interface for disputed savings data
- */
-export interface DisputedSavingsData {
-  bankBalance: number,
-  investmentBalance: number,
-  assetBalance: number,
-  creditBalance: number,
-  total: number
-}
-
-/**
  * Interface for deduction data
  */
 export interface DeductionData {
@@ -434,21 +423,24 @@ export interface FinancialEligibilityData {
   propertySet: PropertySetData[]
   clientData: {
     income: IncomeData,
-    savings: SavingsData,
+    savings: SavingsData | null,
     deductions: DeductionData
   }
   partnerData: {
     partnerIncome: IncomeData,
-    partnerSavings: SavingsData,
+    partnerSavings: SavingsData | null,
     partnerDeductions: DeductionData
   }
-  disputedSavings: DisputedSavingsData;
+  disputedSavings: SavingsData | null ;
   disregards: string[];
   dependantsYoung: number;
   dependantsOld: number;
   under18RegularPayment?: boolean;
   under18HasValuables?: boolean;
   state: String;
+  hasPassportedProceedingsLetter: boolean;
+  passportedBenefits: boolean;
+  under18passportedBenefits: boolean;
 }
 
 /**

--- a/types/api-types.ts
+++ b/types/api-types.ts
@@ -441,6 +441,7 @@ export interface FinancialEligibilityData {
   hasPassportedProceedingsLetter: boolean;
   passportedBenefits: boolean;
   under18passportedBenefits: boolean;
+  category: string;
 }
 
 /**

--- a/views/case_details/_financial-eligibility-partial.njk
+++ b/views/case_details/_financial-eligibility-partial.njk
@@ -36,94 +36,100 @@
       }, {
         text: under17Text
       }
-    ],
-    [
-      {
-        text: t("common.financialEligibility.details.under18RegularPayment")
-      }, {
-        text: under18RegularPayment
-      }
-    ],
-    [
-      {
-        text: t("common.financialEligibility.details.under18HasValuables")
-      }, {
-        text: under18HasValuables
-      }
-    ],
-    [
-      {
-        text: t("common.financialEligibility.details.hasPartner")
-      }, {
-        text: partnerText
-      }
-    ],
-    [
-      {
-        text: t("common.financialEligibility.details.age60OrOver")
-      }, {
-        text: over60Text
-      }
     ]
   ] %}
-
-  {{ govukTable({
-      caption: "About you",
-      captionClasses: "govuk-table__caption--m",
-      firstCellIsHeader: true,
-      classes: "eligibility-table",
-      rows: rows
-    }) }}
-
-  {{ govukTable({
-      caption: "Benefits",
-      captionClasses: "govuk-table__caption--m",
-      firstCellIsHeader: true,
-      classes: "eligibility-table",
-      rows: [
-        [
-          {
-            text: t("common.financialEligibility.details.universalCredit")
-          },
-          {
-            text: universalCredit
-          }
-        ],
-        [
-          {
-            text: t("common.financialEligibility.details.incomeSupport")
-          },
-          {
-            text: incomeSupport
-          }
-        ],
-        [
-          {
-            text: t("common.financialEligibility.details.incomeBasedJSA")
-          },
-          {
-            text: jobSeekers
-          }
-        ],
-        [
-          {
-            text: t("common.financialEligibility.details.pensionCredit")
-          },
-          {
-            text: pensionCredit
-          }
-        ],
-        [
-          {
-            text: t("common.financialEligibility.details.employmentSupport")
-          },
-          {
-            text: employmentSupport
-          }
-        ]
+  {% if financialEligibility.under18passportedBenefits %}
+    {% set rows = rows.concat([
+      [
+        {
+          text: t("common.financialEligibility.details.under18RegularPayment")
+        }, {
+          text: under18RegularPayment
+        }
+      ], 
+      [
+        {
+          text: t("common.financialEligibility.details.under18HasValuables")
+        }, {
+          text: under18HasValuables
+        }
       ]
-    }) }}
-
+    ]) %} 
+  {% else %}
+    {% set rows = rows.concat([
+      [
+        {
+          text: t("common.financialEligibility.details.hasPartner")
+        }, {
+          text: partnerText
+        }
+      ],
+      [
+        {
+          text: t("common.financialEligibility.details.age60OrOver")
+        }, {
+          text: over60Text
+        }
+      ]
+    ]) %} 
+  {% endif %}
+  {{ govukTable({
+    caption: "About you",
+    captionClasses: "govuk-table__caption--m",
+    firstCellIsHeader: true,
+    classes: "eligibility-table",
+    rows: rows
+  }) }}
+  {% if not financialEligibility.under18passportedBenefits %}
+    {{ govukTable({
+        caption: "Benefits",
+        captionClasses: "govuk-table__caption--m",
+        firstCellIsHeader: true,
+        classes: "eligibility-table",
+        rows: [
+          [
+            {
+              text: t("common.financialEligibility.details.universalCredit")
+            },
+            {
+              text: universalCredit
+            }
+          ],
+          [
+            {
+              text: t("common.financialEligibility.details.incomeSupport")
+            },
+            {
+              text: incomeSupport
+            }
+          ],
+          [
+            {
+              text: t("common.financialEligibility.details.incomeBasedJSA")
+            },
+            {
+              text: jobSeekers
+            }
+          ],
+          [
+            {
+              text: t("common.financialEligibility.details.pensionCredit")
+            },
+            {
+              text: pensionCredit
+            }
+          ],
+          [
+            {
+              text: t("common.financialEligibility.details.employmentSupport")
+            },
+            {
+            text: employmentSupport
+           }
+          ]
+        ]
+      }) }}
+  {% endif %}
   <div>{{ editAssessmentButtonHtml | safe }}</div>
 {% endset -%}
 
@@ -145,32 +151,40 @@
         {% endif %}
       </h3>
 
+      {% set propertyRows = [
+        [
+          { text: t("common.financialEligibility.finances.propertyValue") },
+          { text: (property.value | formatFinancialData) }
+        ],
+        [
+          { text: t("common.financialEligibility.finances.mortgageLeft") },
+          { text: (property.mortgageLeft | formatFinancialData) }
+        ],
+        [
+          { text: t("common.financialEligibility.finances.mainProperty") },
+          { text: "Yes" if property.main else "No" }
+        ],
+        [
+          { text: t("common.financialEligibility.finances.propertyShare") },
+          { text: property.share + "%" }
+        ]
+      ] %}
+      
+      {% if financialEligibility.disputedSavings is not null %}
+        {% set propertyRows = propertyRows.concat([
+          [
+            { text: t("common.financialEligibility.finances.disputedProperty") },
+            { text: "Yes" if property.disputed else "No" }
+          ]
+        ]) %}
+      {% endif %}
+
       {{ govukTable({
         firstCellIsHeader: true,
         classes: "eligibility-table",
-        rows: [
-          [
-            { text: t("common.financialEligibility.finances.propertyValue") },
-            { text: (property.value | formatFinancialData) }
-          ],
-          [
-            { text: t("common.financialEligibility.finances.mortgageLeft") },
-            { text: (property.mortgageLeft | formatFinancialData) }
-          ],
-          [
-            { text: t("common.financialEligibility.finances.mainProperty") },
-            { text: "Yes" if property.main else "No" }
-          ],
-          [
-            { text: t("common.financialEligibility.finances.propertyShare") },
-            { text: property.share + "%" }
-          ],
-          [
-            { text: t("common.financialEligibility.finances.disputedProperty")}, 
-            { text: "Yes" if property.disputed else "No" }
-          ]
-        ]
+        rows: propertyRows
       }) }}
+
     {% endfor %}
   {% else %}
     <p class="govuk-body">No property data</p>
@@ -655,41 +669,89 @@
   <div>{{ editAssessmentButtonHtml | safe }}</div>
 {% endset -%}
 
+{% set tabs = [
+  {
+    label: "Details",
+    id: "details",
+    panel: {
+      html: detailsHtml
+    }
+  },
+  {
+    label: "Finances",
+    id: "finances",
+    panel: {
+      html: financesHtml
+    }
+  },
+  {
+    label: "Income",
+    id: "income",
+    panel: {
+      html: incomeHtml
+    }
+  },
+  {
+    label: "Expenses",
+    id: "expenses",
+    panel: {
+      html: expensesHtml
+    }
+  }
+] %}
+
+{% if financialEligibility.under18passportedBenefits %}
+
+  {% set tabs = tabs.slice(0, 1) %}
+
+{% elseif financialEligibility.passportedBenefits %}
+
+  {% set tabs = tabs.slice(0, 2) %}
+
+{% endif %}
+
 <h2 class="govuk-heading-m">{{ t('pages.caseDetails.tabs.financialEligibility') }}</h2>
 <div class="financial-eligibility-alert">
 {{ financialEligibilityAlert(financialEligibility.state) }}
 </div>
 
-{{ govukTabs({
+{% if financialEligibility.hasPassportedProceedingsLetter %}
+
+  <p class="govuk-body govuk-!-font-weight-bold">
+    {{ t('common.financialEligibility.message.noMeansTestTitle') }}
+  </p>
+
+  <p class="govuk-body">
+    {{ t('common.financialEligibility.message.noMeansTestBody') }}
+  </p>
+
+{% else %}
+
+  {% if financialEligibility.under18passportedBenefits %}
+
+    <p class="govuk-body govuk-!-font-weight-bold">
+      {{ t('common.financialEligibility.message.fullTestNotRequiredTitle') }}
+    </p>
+
+    <p class="govuk-body">
+      {{ t('common.financialEligibility.message.fullTestNotRequiredBody') }}
+    </p>
+
+  {% elseif financialEligibility.passportedBenefits %}
+
+    <p class="govuk-body govuk-!-font-weight-bold">
+      {{ t('common.financialEligibility.message.incomeAssessmentNotRequiredTitle') }}
+    </p>
+
+    <p class="govuk-body">
+      {{ t('common.financialEligibility.message.incomeAssessmentNotRequiredBody') }}
+    </p>
+
+  {% endif %}
+
+  {{ govukTabs({
     id: "financial-eligibility-tabs",
-    items: [
-      {
-        label: "Details",
-        id: "details",
-        panel: {
-            html: detailsHtml
-        }
-      },
-      {
-        label: "Finances",
-        id: "finances",
-        panel: {
-            html: financesHtml
-        }
-      },
-      {
-        label: "Income",
-        id: "income",
-        panel: {
-            html: incomeHtml
-        }
-      },
-      {
-        label: "Expenses",
-        id: "expenses",
-        panel: {
-             html: expensesHtml
-        }
-      }
-    ]
-}) }}
+    items: tabs
+  }) }}
+
+{% endif %}

--- a/views/case_details/_financial-eligibility-partial.njk
+++ b/views/case_details/_financial-eligibility-partial.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/alert/macro.njk" import mojAlert %}
 {% from "components/financialEligibilityAlert.njk" import financialEligibilityAlert %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% set editAssessmentButtonHtml %}
   {{
@@ -717,35 +718,25 @@
 
 {% if financialEligibility.hasPassportedProceedingsLetter %}
 
-  <p class="govuk-body govuk-!-font-weight-bold">
-    {{ t('common.financialEligibility.message.noMeansTestTitle') }}
-  </p>
-
-  <p class="govuk-body">
+  {% call govukInsetText() %}
+    <strong>{{ t('common.financialEligibility.message.noMeansTestTitle') }}</strong><br>
     {{ t('common.financialEligibility.message.noMeansTestBody') }}
-  </p>
+  {% endcall %}
 
 {% else %}
-
   {% if financialEligibility.under18passportedBenefits %}
 
-    <p class="govuk-body govuk-!-font-weight-bold">
-      {{ t('common.financialEligibility.message.fullTestNotRequiredTitle') }}
-    </p>
-
-    <p class="govuk-body">
+    {% call govukInsetText() %}
+      <strong>{{ t('common.financialEligibility.message.fullTestNotRequiredTitle') }}</strong><br>
       {{ t('common.financialEligibility.message.fullTestNotRequiredBody') }}
-    </p>
+    {% endcall %}
 
   {% elseif financialEligibility.passportedBenefits %}
 
-    <p class="govuk-body govuk-!-font-weight-bold">
-      {{ t('common.financialEligibility.message.incomeAssessmentNotRequiredTitle') }}
-    </p>
-
-    <p class="govuk-body">
+    {% call govukInsetText() %}
+      <strong>{{ t('common.financialEligibility.message.incomeAssessmentNotRequiredTitle') }}</strong><br>
       {{ t('common.financialEligibility.message.incomeAssessmentNotRequiredBody') }}
-    </p>
+    {% endcall %}
 
   {% endif %}
 
@@ -753,5 +744,4 @@
     id: "financial-eligibility-tabs",
     items: tabs
   }) }}
-
 {% endif %}

--- a/views/case_details/_financial-eligibility-partial.njk
+++ b/views/case_details/_financial-eligibility-partial.njk
@@ -146,7 +146,6 @@
 {% endset -%}
 
 {% set financesHtml %}
-
   <h2 class="govuk-heading-m">Properties</h2>
   {% if financialEligibility.propertySet and financialEligibility.propertySet.length %}
     {% for property in financialEligibility.propertySet %}
@@ -182,7 +181,7 @@
         ]
       ] %}
       
-      {% if financialEligibility.disputedSavings is not null %}
+      {% if financialEligibility.category == 'debt' or financialEligibility.category == 'family' %}
         {% set propertyRows = propertyRows.concat([
           [
             { text: t("common.financialEligibility.finances.disputedProperty") },
@@ -289,7 +288,7 @@
     }) }}
   {% endif %}
 
-  {% if financialEligibility.disputedSavings %}
+  {% if financialEligibility.category == 'debt' or financialEligibility.category == 'family' %}
     <h2 class="govuk-heading-m">Your disputed savings</h2>
 
     {% set disputedSavings = financialEligibility.disputedSavings %}
@@ -348,7 +347,7 @@
       </tbody>
     </table>
   {% else %}
-    <p> {{t("common.notProvided")}} </p>
+    <p> {{t("common.none")}} </p>
   {% endif %}
 
   <div>{{ editAssessmentButtonHtml | safe }}</div>

--- a/views/case_details/_financial-eligibility-partial.njk
+++ b/views/case_details/_financial-eligibility-partial.njk
@@ -30,6 +30,25 @@
   {% set employmentSupport = "Yes" if financialEligibility.specificBenefits.employmentSupport else "No"%}
   {% set incomeSupport = "Yes" if financialEligibility.specificBenefits.incomeSupport else "No"%}
 
+  {% set partnerAndAgeRows = [
+    [
+      {
+        text: t("common.financialEligibility.details.hasPartner")
+      },
+      {
+        text: partnerText
+      }
+    ],
+    [
+      {
+        text: t("common.financialEligibility.details.age60OrOver")
+      },
+      {
+        text: over60Text
+      }
+    ]
+  ] %}
+
   {% set rows = [
     [
       {
@@ -49,7 +68,7 @@
         }
       ]
     ]) %}
-    {% if financialEligibility.isUnder17 and financialEligibility.under18RegularPayment %}
+    {% if not financialEligibility.under18RegularPayment %}
       {% set rows = rows.concat([ 
         [
           {
@@ -60,23 +79,11 @@
         ]
       ]) %} 
     {% endif %}
+    {% if financialEligibility.under18HasValuables or financialEligibility.under18RegularPayment %}
+       {% set rows = rows.concat(partnerAndAgeRows) %}
+    {% endif %}
   {% else %}
-    {% set rows = rows.concat([
-      [
-        {
-          text: t("common.financialEligibility.details.hasPartner")
-        }, {
-          text: partnerText
-        }
-      ],
-      [
-        {
-          text: t("common.financialEligibility.details.age60OrOver")
-        }, {
-          text: over60Text
-        }
-      ]
-    ]) %} 
+     {% set rows = rows.concat(partnerAndAgeRows) %}
   {% endif %}
   {{ govukTable({
     caption: "About you",

--- a/views/case_details/_financial-eligibility-partial.njk
+++ b/views/case_details/_financial-eligibility-partial.njk
@@ -39,7 +39,7 @@
       }
     ]
   ] %}
-  {% if financialEligibility.under18passportedBenefits %}
+  {% if financialEligibility.isUnder17 %}
     {% set rows = rows.concat([
       [
         {
@@ -47,15 +47,19 @@
         }, {
           text: under18RegularPayment
         }
-      ], 
-      [
-        {
-          text: t("common.financialEligibility.details.under18HasValuables")
-        }, {
-          text: under18HasValuables
-        }
       ]
-    ]) %} 
+    ]) %}
+    {% if financialEligibility.isUnder17 and financialEligibility.under18RegularPayment %}
+      {% set rows = rows.concat([ 
+        [
+          {
+            text: t("common.financialEligibility.details.under18HasValuables")
+          }, {
+            text: under18HasValuables
+          }
+        ]
+      ]) %} 
+    {% endif %}
   {% else %}
     {% set rows = rows.concat([
       [


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-3281)

## What changed and Why?

Scenario | Condition | Display
-- | -- | --
Exception | has_passported_proceedings_letter = true | No financial information displayed Banner to display means test exemption/financial-eligibility
Under 18 | under_18_passported = true | Display only:is_you_under_18under_18_receive_regular_paymentunder_18_has_valuables Banner to display client is eligible based on simplified approach
Passported | on_passported_benefits = true | Do not display the following tabs:IncomeExpenses Banner to display income assessment not required
Partner | has_partner = false | Do not display the following sections:Your partner’s savingsYour partner’s incomeYour partner’s expenses
Disputed assets | If category is not debt or family | Do not display the following sections:Disputed savingsDo not display the following question:Is the property disputed?

## Guidance to review (optional)

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.