### PR TITLE
EL-3162: Add test annotation to kubernetes deployment

### DIFF
--- a/deploy/laa-manage-your-civil-cases/values/uat.yaml
+++ b/deploy/laa-manage-your-civil-cases/values/uat.yaml
@@ -20,7 +20,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "mcc-github-action-service-account"
 
-podAnnotations: {}
+podAnnotations:
+  testAnnotation: "test-value"
 podLabels: {}
 
 podSecurityContext:

--- a/deploy/laa-manage-your-civil-cases/values/uat.yaml
+++ b/deploy/laa-manage-your-civil-cases/values/uat.yaml
@@ -20,8 +20,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "mcc-github-action-service-account"
 
-podAnnotations:
-  testAnnotation: "test-value"
+podAnnotations: {}
 podLabels: {}
 
 podSecurityContext:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,6 +15,7 @@ deploy_branch() {
                 --install --wait \
                 --namespace="${K8S_NAMESPACE}" \
                 --values ./deploy/laa-manage-your-civil-cases/values/"$ENVIRONMENT".yaml \
+                --set podAnnotations.uat-environment="branch" \
                 --set image.repository="$REGISTRY/$REPOSITORY" \
                 --set image.tag="$IMAGE_TAG" \
                 --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER" \


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/EL-3162

## What changed and Why?

This PR adds a custom annotation in order to get this across to the fields in OpenSearch logs:

<img width="497" height="56" alt="image" src="https://github.com/user-attachments/assets/0253ebf3-512c-48ca-abb0-14938003bb63" />

This field isn't being indexed at the moment, and the Cloud Platform team don't seem able to create custom indexes yet, but from what I have gathered, they will eventually be able, so we should have this already in place for when we can do the filtering correctly.

## Guidance to review (optional)

<!-- Provide any useful context for the reviewer:  
- Key areas to focus on in the review
- Any known issues or limitations  
- Dependencies or related changes to consider
-->

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.