### PR TITLE
EL-3292: Prevent health probes from creating Redis sessions

### DIFF
--- a/src/middlewares/setupCsrf.ts
+++ b/src/middlewares/setupCsrf.ts
@@ -233,6 +233,12 @@ export const setupCsrf = (app: Application): void => {
    * @param {NextFunction} next - Callback to pass control to the next middleware.
    */
   app.use((req: Request, res: Response, next: NextFunction): void => {
+    // Health/Status probs are GET-only, unautenticated, render no templates -
+    // skip CSRF token generation for these routes to avoid unnecessary session creation to Redis.
+    if (req.path === '/health' || req.path === '/status') {
+      next();
+      return;
+    }
     if (typeof req.csrfToken === "function") {
       res.locals.csrfToken = req.csrfToken(); // Makes CSRF token available in views
     }

--- a/tests/unit/middleware/setupCsrf.spec.ts
+++ b/tests/unit/middleware/setupCsrf.spec.ts
@@ -7,6 +7,7 @@ import express, { type Application } from 'express';
 import { expect } from 'chai';
 import request from 'supertest';
 import cookieParser from 'cookie-parser';
+import session from 'express-session';
 
 describe('CSRF Protection Middleware', () => {
   describe('Middleware Setup', () => {
@@ -271,5 +272,36 @@ describe('CSRF Protection Middleware', () => {
       expect(mockError.message).to.include('csrf');
     });
   });
-});
 
+  describe('Probe path exclusion', () => {
+    let app: Application;
+
+    beforeEach(() => {
+      app = express();
+      app.set('trust proxy', 1);
+      app.use(session({ secret: 'test-secret', resave: false, saveUninitialized: false, cookie: { secure: true } }));
+      setupCsrf(app);
+      app.get('/health', (req, res) => res.status(200).send('Healthy'));
+      app.get('/status', (req, res) => res.status(200).send('OK'));
+      app.get('/other', (req, res) => res.status(200).send('other'));
+    });
+
+    it('does not set a session cookie for /health', async () => {
+      const response = await request(app).get('/health').set('X-Forwarded-Proto', 'https');
+      expect(response.status).to.equal(200);
+      expect(response.headers['set-cookie']).to.be.undefined;
+    });
+
+    it('does not set a session cookie for /status', async () => {
+      const response = await request(app).get('/status').set('X-Forwarded-Proto', 'https');
+      expect(response.status).to.equal(200);
+      expect(response.headers['set-cookie']).to.be.undefined;
+    });
+
+    it('still exposes a CSRF token for non-probe GET routes', async () => {
+      const response = await request(app).get('/other').set('X-Forwarded-Proto', 'https');
+      expect(response.status).to.equal(200);
+      expect(response.headers['set-cookie']).to.not.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
[Jira ticket](https://dsdmoj.atlassian.net/browse/EL-3292)

## What changed and Why?

I updated the app to skip CSRF token generation for GET /health and /status, so Kubernetes probes stop creating throwaway sessions in Redis.

## Guidance to review (optional)

## Checklist

Before you ask people to review this PR:

- [x] **Tests and linting** are passing.  
- [x] **Branch is up to date** with `main` (no merge conflicts).  
- [x] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [x] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [x] **Diff has been checked** for any unexpected changes.  
- [x] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.