### PR TITLE
EL-3365: Percentage of property can't be a `float` has to be `integer`

### DIFF
--- a/packages/financial-eligibility-journey/src/checkAnswersPage/checkAnswersBlock.ts
+++ b/packages/financial-eligibility-journey/src/checkAnswersPage/checkAnswersBlock.ts
@@ -183,7 +183,7 @@ export const savingsSummaryList = GovUKSummaryList({
     },
     actions: {
       items: [
-        { href: 'savings', text: 'Change', visuallyHiddenText: 'Change, Your savings' },
+        { href: 'your-savings', text: 'Change', visuallyHiddenText: 'Change, Your savings' },
       ],
     },
   },

--- a/packages/financial-eligibility-journey/src/propertiesPage/propertiesBlock.ts
+++ b/packages/financial-eligibility-journey/src/propertiesPage/propertiesBlock.ts
@@ -134,6 +134,10 @@ export const propertySet = CollectionBlock({
             message: Format('Enter the percentage you own of property %1', Loop.Index()),
           }),
           validation({
+            condition: Self().match(Condition.Number.IsInteger()),
+            message: Format('The percentage you own of property %1 must be a whole number', Loop.Index()),
+          }),
+          validation({
             condition: Self().match(Condition.Number.Between(1, 100)),
             message: Format('The percentage you own of property %1 must be a number between 1 and 100', Loop.Index()),
           }),

--- a/tests/playwright/tests/financial-eligibility-forge-finances-journey.spec.ts
+++ b/tests/playwright/tests/financial-eligibility-forge-finances-journey.spec.ts
@@ -152,6 +152,19 @@ test.describe('Financial Eligibility Forge Finances Journey', () => {
       await expect(page.getByRole('link', { name: 'The percentage you own of' })).toBeVisible();
     });
 
+    test('should show validation error when property share percentage has decimals', async ({ page }) => {
+      await page.goto('/cases/PC-1854-6521/financial-eligibility/change/properties'); // Walter White has no properties in mock data
+      await page.getByRole('button', { name: 'Add property' }).click();
+
+      await page.getByRole('spinbutton', { name: 'What is the current market value of the property?' }).first().fill('100000');
+      await page.getByRole('spinbutton', { name: 'How much is left to pay on the mortgage?' }).first().fill('0');
+      await page.getByRole('group', { name: 'Is this your main property?' }).first().getByLabel('Yes').check();
+      await page.getByRole('spinbutton', { name: 'What percentage of the property do you own?' }).first().fill('50.5');
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await expect(page.getByRole('link', { name: 'The percentage you own of property 1 must be a whole number' })).toBeVisible();
+    });
+
     test('should show step-level error when more than one property is marked as main', async ({ page }) => {
       await page.goto('/cases/PC-1854-6521/financial-eligibility/change/properties'); // Walter White has no properties in mock data
       await page.getByRole('button', { name: 'Add property' }).click();


### PR DESCRIPTION
[Jira ticket (if applicable)](https://dsdmoj.atlassian.net/browse/EL-3365)

## What changed and Why?

- If applied, this adds validation so that the `share` input field will not accept `floats` it has to be an `integer`. 

## Guidance to review (optional)

- Bonus: Also corrects the `"Your savings"` change link in check you answers screen

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.